### PR TITLE
Force HttpApi result content-type

### DIFF
--- a/AutoImportServiceCore/AutoImportServiceCore/Modules/HttpApis/Models/HttpApiModel.cs
+++ b/AutoImportServiceCore/AutoImportServiceCore/Modules/HttpApis/Models/HttpApiModel.cs
@@ -51,5 +51,11 @@ namespace AutoImportServiceCore.Modules.HttpApis.Models
         /// Gets or sets the body to send with the request.
         /// </summary>
         public BodyModel Body { get; set; }
+
+        /// <summary>
+        /// Gets or sets the expected content type. This will force the result to be cast to this object.
+        /// Set to null or an empty string to use the Content-Type header of the result (if there is one). 
+        /// </summary>
+        public string ResultContentType { get; set; }
     }
 }

--- a/AutoImportServiceCore/AutoImportServiceCore/Modules/HttpApis/Services/HttpApisService.cs
+++ b/AutoImportServiceCore/AutoImportServiceCore/Modules/HttpApis/Services/HttpApisService.cs
@@ -199,8 +199,22 @@ namespace AutoImportServiceCore.Modules.HttpApis.Services
             // Add all content headers to the result set.
             ExtractHeadersIntoResultSet(resultSet, response.Content.Headers);
 
+            // Determine content type.
+            string contentType = null;
+            if (!String.IsNullOrWhiteSpace(httpApi.ResultContentType))
+            {
+                contentType = httpApi.ResultContentType;
+            }
+            else if (resultSet.ContainsKey("Content-Type"))
+            {
+                contentType = (string) resultSet["Content-Type"]?[0];
+            }
+            
+            // Make sure contentType is not null.
+            contentType ??= String.Empty;
+
             var responseBody = await response.Content.ReadAsStringAsync();
-            if (resultSet.ContainsKey("Content-Type") && ((string)resultSet["Content-Type"][0]).Contains("json"))
+            if (contentType.Contains("json"))
             {
                 if (responseBody.StartsWith("{"))
                 {
@@ -211,7 +225,7 @@ namespace AutoImportServiceCore.Modules.HttpApis.Services
                     resultSet.Add("Body", JArray.Parse(responseBody));
                 }
             }
-            else if (resultSet.ContainsKey("Content-Type") && ((string)resultSet["Content-Type"][0]).Contains("xml"))
+            else if (contentType.Contains("xml"))
             {
                 var xml = new XmlDocument();
                 xml.LoadXml(responseBody);


### PR DESCRIPTION
The result's content type can now be forced to a specific value by setting the ResultContentType property of the HttpApiModel.