### PR TITLE
Load configurations that have been published to development while in …

### DIFF
--- a/WiserTaskScheduler/WiserTaskScheduler/Modules/Wiser/Services/WiserService.cs
+++ b/WiserTaskScheduler/WiserTaskScheduler/Modules/Wiser/Services/WiserService.cs
@@ -140,8 +140,14 @@ namespace WiserTaskScheduler.Modules.Wiser.Services
         {
             // Lock cannot be used inside an async function. This way we can wait till the request has completed.
             return await Task.Run(() =>
-            {
-                var request = new HttpRequestMessage(HttpMethod.Get, $"{wiserSettings.WiserApiUrl}api/v3/templates/entire-tree-view?startFrom=SERVICES{(String.IsNullOrWhiteSpace(wiserSettings.ConfigurationPath) ? "" : $",{wiserSettings.ConfigurationPath}")}&environment={Environments.Live}");
+            {  
+#if DEBUG
+                var environment = Environments.Development;
+#else
+                var environment = Environments.Live;
+#endif
+                
+                var request = new HttpRequestMessage(HttpMethod.Get, $"{wiserSettings.WiserApiUrl}api/v3/templates/entire-tree-view?startFrom=SERVICES{(String.IsNullOrWhiteSpace(wiserSettings.ConfigurationPath) ? "" : $",{wiserSettings.ConfigurationPath}")}&environment={environment}");
                 request.Headers.Add("Authorization", $"Bearer {AccessToken}");
 
                 using var client = new HttpClient();


### PR DESCRIPTION
…debug modus.

When the WTS is run in debug mode in an IDE it will load templates published to development instead of live.

Together with: https://github.com/happy-geeks/wiser/pull/218

https://app.asana.com/0/7257459017111/1203426290923318