### PR TITLE
Add name for WTS to use in error mails.

### DIFF
--- a/WiserTaskScheduler/WiserTaskScheduler/Core/Aggregates/BaseWorkerDependencyAggregate.cs
+++ b/WiserTaskScheduler/WiserTaskScheduler/Core/Aggregates/BaseWorkerDependencyAggregate.cs
@@ -4,6 +4,8 @@ using WiserTaskScheduler.Modules.RunSchemes.Interfaces;
 using WiserTaskScheduler.Modules.Wiser.Interfaces;
 using GeeksCoreLibrary.Core.DependencyInjection.Interfaces;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using WiserTaskScheduler.Core.Models;
 
 namespace WiserTaskScheduler.Core.Aggregates
 {
@@ -26,6 +28,9 @@ namespace WiserTaskScheduler.Core.Aggregates
 
         /// <inheritdoc />
         public IErrorNotificationService ErrorNotificationService { get; }
+        
+        /// <inheritdoc />
+        public WtsSettings WtsSettings { get; }
 
         /// <summary>
         /// Creates a new instance of <see cref="BaseWorkerDependencyAggregate"/>.
@@ -34,13 +39,16 @@ namespace WiserTaskScheduler.Core.Aggregates
         /// <param name="logger"></param>
         /// <param name="runSchemesService"></param>
         /// <param name="wiserDashboardService"></param>
-        public BaseWorkerDependencyAggregate(ILogService logService, ILogger<BaseWorker> logger, IRunSchemesService runSchemesService, IWiserDashboardService wiserDashboardService, IErrorNotificationService errorNotificationService)
+        /// <param name="errorNotificationService"></param>
+        /// <param name="wtsSettings"></param>
+        public BaseWorkerDependencyAggregate(ILogService logService, ILogger<BaseWorker> logger, IRunSchemesService runSchemesService, IWiserDashboardService wiserDashboardService, IErrorNotificationService errorNotificationService, IOptions<WtsSettings> wtsSettings)
         {
             LogService = logService;
             Logger = logger;
             RunSchemesService = runSchemesService;
             WiserDashboardService = wiserDashboardService;
             ErrorNotificationService = errorNotificationService;
+            WtsSettings = wtsSettings.Value;
         }
     }
 }

--- a/WiserTaskScheduler/WiserTaskScheduler/Core/Interfaces/IBaseWorkerDependencyAggregate.cs
+++ b/WiserTaskScheduler/WiserTaskScheduler/Core/Interfaces/IBaseWorkerDependencyAggregate.cs
@@ -2,6 +2,7 @@ using WiserTaskScheduler.Core.Workers;
 using WiserTaskScheduler.Modules.RunSchemes.Interfaces;
 using WiserTaskScheduler.Modules.Wiser.Interfaces;
 using Microsoft.Extensions.Logging;
+using WiserTaskScheduler.Core.Models;
 
 namespace WiserTaskScheduler.Core.Interfaces
 {
@@ -34,5 +35,10 @@ namespace WiserTaskScheduler.Core.Interfaces
         /// Gets the <see cref="IErrorNotificationService"/>.
         /// </summary>
         IErrorNotificationService ErrorNotificationService { get; }
+
+        /// <summary>
+        /// Gets or sets the <see cref="WtsSettings"/>.
+        /// </summary>
+        WtsSettings WtsSettings { get; }
     }
 }

--- a/WiserTaskScheduler/WiserTaskScheduler/Core/Models/WtsSettings.cs
+++ b/WiserTaskScheduler/WiserTaskScheduler/Core/Models/WtsSettings.cs
@@ -1,4 +1,5 @@
-﻿using WiserTaskScheduler.Core.Models.Cleanup;
+﻿using System;
+using WiserTaskScheduler.Core.Models.Cleanup;
 using WiserTaskScheduler.Modules.Slack.modules;
 using WiserTaskScheduler.Modules.Wiser.Models;
 
@@ -9,6 +10,17 @@ namespace WiserTaskScheduler.Core.Models
     /// </summary>
     public class WtsSettings
     {
+        private string name;
+
+        /// <summary>
+        /// Gets or sets the name of the WTS to use for communication.
+        /// </summary>
+        public string Name
+        {
+            get => String.IsNullOrWhiteSpace(name) ? $"Wiser Task Scheduler ({Environment.MachineName})" : name;
+            set => name = value;
+        }
+
         /// <summary>
         /// Gets or sets the settings of the <see cref="MainService"/>.
         /// </summary>

--- a/WiserTaskScheduler/WiserTaskScheduler/Core/Services/ConfigurationsService.cs
+++ b/WiserTaskScheduler/WiserTaskScheduler/Core/Services/ConfigurationsService.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using GeeksCoreLibrary.Core.DependencyInjection.Interfaces;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Newtonsoft.Json.Linq;
 using WiserTaskScheduler.Core.Enums;
 using WiserTaskScheduler.Core.Helpers;
@@ -22,6 +23,7 @@ namespace WiserTaskScheduler.Core.Services
         private readonly ILogger<ConfigurationsService> logger;
         private readonly IActionsServiceFactory actionsServiceFactory;
         private readonly IErrorNotificationService errorNotificationService;
+        private readonly WtsSettings wtsSettings;
 
         private readonly SortedList<int, ActionModel> actions;
         private readonly Dictionary<string, IActionsService> actionsServices;
@@ -45,12 +47,15 @@ namespace WiserTaskScheduler.Core.Services
         /// <param name="logService">The service to use for logging.</param>
         /// <param name="logger"></param>
         /// <param name="actionsServiceFactory"></param>
-        public ConfigurationsService(ILogService logService, ILogger<ConfigurationsService> logger, IActionsServiceFactory actionsServiceFactory, IErrorNotificationService errorNotificationService)
+        /// <param name="errorNotificationService"></param>
+        /// <param name="wtsSettings"></param>
+        public ConfigurationsService(ILogService logService, ILogger<ConfigurationsService> logger, IActionsServiceFactory actionsServiceFactory, IErrorNotificationService errorNotificationService, IOptions<WtsSettings> wtsSettings)
         {
             this.logService = logService;
             this.logger = logger;
             this.actionsServiceFactory = actionsServiceFactory;
             this.errorNotificationService = errorNotificationService;
+            this.wtsSettings = wtsSettings.Value;
 
             actions = new SortedList<int, ActionModel>();
             actionsServices = new Dictionary<string, IActionsService>();
@@ -208,7 +213,7 @@ namespace WiserTaskScheduler.Core.Services
             catch (Exception e)
             {
                 await logService.LogCritical(logger, LogScopes.StartAndStop, LogSettings, $"Aborted {configurationServiceName} due to exception in time ID '{timeId}' and order '{currentOrder}', will try again next time. Exception {e}", configurationServiceName, timeId, currentOrder);
-                await errorNotificationService.NotifyOfErrorByEmailAsync(serviceFailedNotificationEmails, $"Service '{configurationServiceName}' with time ID '{timeId}' failed.", $"Wiser Task Scheduler failed during the executing of service '{configurationServiceName}' with time ID '{timeId}' and has therefore been aborted. Please check the logs for more details. A new attempt will be made during the next run.", LogSettings, LogScopes.RunStartAndStop, configurationServiceName);
+                await errorNotificationService.NotifyOfErrorByEmailAsync(serviceFailedNotificationEmails, $"Service '{configurationServiceName}' with time ID '{timeId}' of '{wtsSettings.Name}' failed.", $"Wiser Task Scheduler '{wtsSettings.Name}' failed during the executing of service '{configurationServiceName}' with time ID '{timeId}' and has therefore been aborted. Please check the logs for more details. A new attempt will be made during the next run.", LogSettings, LogScopes.RunStartAndStop, configurationServiceName);
             }
         }
 

--- a/WiserTaskScheduler/WiserTaskScheduler/Core/Services/MainService.cs
+++ b/WiserTaskScheduler/WiserTaskScheduler/Core/Services/MainService.cs
@@ -341,7 +341,7 @@ namespace WiserTaskScheduler.Core.Services
                 await logService.LogCritical(logger, LogScopes.StartAndStop, configuration.LogSettings, $"{configuration.ServiceName} with time ID '{runScheme.TimeId}' could not be started due to exception {e}", configuration.ServiceName, runScheme.TimeId);
                 await wiserDashboardService.UpdateServiceAsync(configuration.ServiceName, runScheme.TimeId, state: "crashed");
 
-                await errorNotificationService.NotifyOfErrorByEmailAsync(String.IsNullOrWhiteSpace(configuration.ServiceFailedNotificationEmails) ?configuration.ServiceFailedNotificationEmails : wtsSettings.ServiceFailedNotificationEmails, $"Service '{configuration.ServiceName}' with time ID '{runScheme.TimeId}' could not be started.", $"Wiser Task Scheduler could not start service '{configuration.ServiceName}' with time ID '{runScheme.TimeId}'. Please check the logs for more details.", runScheme.LogSettings, LogScopes.StartAndStop, configuration.ServiceName);
+                await errorNotificationService.NotifyOfErrorByEmailAsync(String.IsNullOrWhiteSpace(configuration.ServiceFailedNotificationEmails) ? configuration.ServiceFailedNotificationEmails : wtsSettings.ServiceFailedNotificationEmails, $"Service '{configuration.ServiceName}' with time ID '{runScheme.TimeId}' of '{wtsSettings.Name}' could not be started.", $"Wiser Task Scheduler '{wtsSettings.Name}' could not start service '{configuration.ServiceName}' with time ID '{runScheme.TimeId}'. Please check the logs for more details.", runScheme.LogSettings, LogScopes.StartAndStop, configuration.ServiceName);
 
                 return;
             }

--- a/WiserTaskScheduler/WiserTaskScheduler/Core/Workers/BaseWorker.cs
+++ b/WiserTaskScheduler/WiserTaskScheduler/Core/Workers/BaseWorker.cs
@@ -7,6 +7,7 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using WiserTaskScheduler.Core.Enums;
 using WiserTaskScheduler.Core.Interfaces;
+using WiserTaskScheduler.Core.Models;
 using WiserTaskScheduler.Modules.RunSchemes.Interfaces;
 using WiserTaskScheduler.Modules.RunSchemes.Models;
 using WiserTaskScheduler.Modules.Wiser.Interfaces;
@@ -39,6 +40,7 @@ namespace WiserTaskScheduler.Core.Workers
         private readonly IRunSchemesService runSchemesService;
         private readonly IWiserDashboardService wiserDashboardService;
         private readonly IErrorNotificationService errorNotificationService;
+        private readonly WtsSettings wtsSettings;
         
         private string serviceFailedNotificationEmails;
 
@@ -53,6 +55,7 @@ namespace WiserTaskScheduler.Core.Workers
             runSchemesService = baseWorkerDependencyAggregate.RunSchemesService;
             wiserDashboardService = baseWorkerDependencyAggregate.WiserDashboardService;
             errorNotificationService = baseWorkerDependencyAggregate.ErrorNotificationService;
+            wtsSettings = baseWorkerDependencyAggregate.WtsSettings;
         }
 
         /// <summary>
@@ -185,7 +188,7 @@ namespace WiserTaskScheduler.Core.Workers
                     await wiserDashboardService.UpdateServiceAsync(ConfigurationName, RunScheme.TimeId, state: "crashed");
                 }
                 
-                await errorNotificationService.NotifyOfErrorByEmailAsync(serviceFailedNotificationEmails, $"Service '{ConfigurationName ?? Name}'{(RunScheme.TimeId > 0 ? $" with time ID '{RunScheme.TimeId}'" : "")} crashed.", $"Wiser Task Scheduler crashed while executing the service '{ConfigurationName ?? Name}'{(RunScheme.TimeId > 0 ? $" with time ID '{RunScheme.TimeId}'" : "")} and is therefore shutdown. Please check the logs for more details. A restart is required to start the service again.", RunScheme.LogSettings, LogScopes.StartAndStop, ConfigurationName ?? Name);
+                await errorNotificationService.NotifyOfErrorByEmailAsync(serviceFailedNotificationEmails, $"Service '{ConfigurationName ?? Name}'{(RunScheme.TimeId > 0 ? $" with time ID '{RunScheme.TimeId}'" : "")} of '{wtsSettings.Name}' crashed.", $"Wiser Task Scheduler '{wtsSettings.Name}' crashed while executing the service '{ConfigurationName ?? Name}'{(RunScheme.TimeId > 0 ? $" with time ID '{RunScheme.TimeId}'" : "")} and is therefore shutdown. Please check the logs for more details. A restart is required to start the service again.", RunScheme.LogSettings, LogScopes.StartAndStop, ConfigurationName ?? Name);
             }
         }
 

--- a/WiserTaskScheduler/WiserTaskScheduler/Program.cs
+++ b/WiserTaskScheduler/WiserTaskScheduler/Program.cs
@@ -40,7 +40,7 @@ namespace WiserTaskScheduler
             Host.CreateDefaultBuilder(args)
                 .UseWindowsService((options) =>
                 {
-                    options.ServiceName = "Auto import service";
+                    options.ServiceName = "Wiser Task Scheduler";
                 })
                 .ConfigureAppConfiguration((hostingContext, config) =>
                 {

--- a/WiserTaskScheduler/WiserTaskScheduler/appsettings.json
+++ b/WiserTaskScheduler/WiserTaskScheduler/appsettings.json
@@ -31,6 +31,7 @@
     }
   },
   "Wts": {
+    "Name": "WTS development",
     "SecretsBaseDirectory": "C:\\WiserSecrets\\",
     "MainService": {
       "LocalConfiguration": "C:\\WTS configurations\\WTSTestSettings.xml",


### PR DESCRIPTION
It can become unclear what WTS has send an email if configuration names are used in multiple WTS services (such as "General").

A name can be provided to indicate which WTS needs attention.

https://app.asana.com/0/7257459017111/1203798696952557