### PR TITLE
Create and update tables before starting.

### DIFF
--- a/WiserTaskScheduler/WiserTaskScheduler/Core/Services/LogService.cs
+++ b/WiserTaskScheduler/WiserTaskScheduler/Core/Services/LogService.cs
@@ -20,7 +20,6 @@ namespace WiserTaskScheduler.Core.Services
     {
         private readonly IServiceProvider serviceProvider;
 
-        private bool updatedLogTable;
         private readonly SlackSettings slackSettings;
         
         public LogService(IServiceProvider serviceProvider, IOptions<WtsSettings> wtsSettings)
@@ -81,14 +80,6 @@ namespace WiserTaskScheduler.Core.Services
                         try
                         {
                             using var databaseConnection = scope.ServiceProvider.GetRequiredService<IDatabaseConnection>();
-                            
-                            // Update log table if it has not already been done since launch. The table definitions can only change when the WTS restarts with a new update.
-                            if (!updatedLogTable)
-                            {
-                                var databaseHelpersService = scope.ServiceProvider.GetRequiredService<IDatabaseHelpersService>();
-                                await databaseHelpersService.CheckAndUpdateTablesAsync(new List<string> {WiserTableNames.WtsLogs});
-                                updatedLogTable = true;
-                            }
 
                             databaseConnection.ClearParameters();
                             databaseConnection.AddParameter("message", message);

--- a/WiserTaskScheduler/WiserTaskScheduler/Modules/Branches/Services/BranchQueueService.cs
+++ b/WiserTaskScheduler/WiserTaskScheduler/Modules/Branches/Services/BranchQueueService.cs
@@ -80,9 +80,6 @@ namespace WiserTaskScheduler.Modules.Branches.Services
             databaseConnection.ClearParameters();
 
             await logService.LogInformation(logger, LogScopes.RunStartAndStop, branchQueue.LogSettings, $"Start handling branches queue in time id: {branchQueue.TimeId}, order: {branchQueue.Order}", configurationServiceName, branchQueue.TimeId, branchQueue.Order);
-
-            // Make sure the wiser_branch_queue table exists, so that we don't get errors when running the WTS for new customers.
-            await databaseHelpersService.CheckAndUpdateTablesAsync(new List<string> {WiserTableNames.WiserBranchesQueue});
             
             // Use .NET time and not database time, because we often use DigitalOcean and they have their timezone set to UTC by default.
             databaseConnection.AddParameter("now", DateTime.Now);

--- a/WiserTaskScheduler/WiserTaskScheduler/Program.cs
+++ b/WiserTaskScheduler/WiserTaskScheduler/Program.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
@@ -33,10 +34,16 @@ namespace WiserTaskScheduler
     {
         public static async Task Main(string[] args)
         {
-            await CreateHostBuilder(args).Build().RunAsync();
+            var host = CreateHostBuilder(args).Build();
+            
+            using var scope = host.Services.CreateScope();
+            var databaseHelpersService = scope.ServiceProvider.GetRequiredService<IDatabaseHelpersService>();
+            await databaseHelpersService.CheckAndUpdateTablesAsync(new List<string> {WiserTableNames.WtsLogs, WiserTableNames.WtsServices});
+            
+            await host.RunAsync();
         }
 
-        public static IHostBuilder CreateHostBuilder(string[] args) =>
+        private static IHostBuilder CreateHostBuilder(string[] args) =>
             Host.CreateDefaultBuilder(args)
                 .UseWindowsService((options) =>
                 {
@@ -55,14 +62,14 @@ namespace WiserTaskScheduler
                     var secretsBasePath = hostingContext.Configuration.GetSection("Wts").GetValue<string>("SecretsBaseDirectory");
 
                     config.AddJsonFile($"{secretsBasePath}wts-appsettings-secrets.json", false, false)
-                            .AddJsonFile($"appsettings.{hostingContext.HostingEnvironment.EnvironmentName}.json", true, true);
+                        .AddJsonFile($"appsettings.{hostingContext.HostingEnvironment.EnvironmentName}.json", true, true);
                 })
                 .ConfigureServices((hostContext, services) =>
                 {
                     ConfigureSettings(hostContext.Configuration, services);
                     ConfigureHostedServices(services);
                     ConfigureWtsServices(services, hostContext);
-                    
+
                     Log.Logger = new LoggerConfiguration()
                         .ReadFrom.Configuration(hostContext.Configuration)
                         .CreateLogger();


### PR DESCRIPTION
Due to the MainService and CleanupService being on different threads starting both when running the WTS it was possible to have a race condition causing both threads to update columns resulting in an exception.

This check is now done before launching to prevent this.

https://app.asana.com/0/7257459017111/1202846788164815