### PR TITLE
Only send the error notifications and Slack messages during production.

### DIFF
--- a/WiserTaskScheduler/WiserTaskScheduler/Core/Services/ErrorNotificationService.cs
+++ b/WiserTaskScheduler/WiserTaskScheduler/Core/Services/ErrorNotificationService.cs
@@ -34,16 +34,21 @@ public class ErrorNotificationService : IErrorNotificationService, ISingletonSer
     }
     
     /// <inheritdoc />
+#pragma warning disable CS1998
     public async Task NotifyOfErrorByEmailAsync(string emails, string subject, string content, LogSettings logSettings, LogScopes logScope, string configurationName)
     {
+#if !DEBUG
+        // Only send mails for production Wiser Task Schedulers to prevent exceptions during developing/testing to trigger it.
         if (String.IsNullOrWhiteSpace(emails))
         {
             return;
         }
-        
+
         var emailList = emails.Split(";").ToList();
         await NotifyOfErrorByEmailAsync(emailList, subject, content, logSettings, logScope, configurationName);
+#endif
     }
+#pragma warning restore CS1998
 
     /// <inheritdoc />
     public async Task NotifyOfErrorByEmailAsync(List<string> emails, string subject, string content, LogSettings logSettings, LogScopes logScope, string configurationName)

--- a/WiserTaskScheduler/WiserTaskScheduler/Core/Services/LogService.cs
+++ b/WiserTaskScheduler/WiserTaskScheduler/Core/Services/LogService.cs
@@ -106,7 +106,10 @@ namespace WiserTaskScheduler.Core.Services
                         }
                         logger.Log(logLevel, message);
 
-                        // If there is a slackChannel and SlackAccesToken Send a slack message if critical error.
+#if !DEBUG
+                        // Only send messages to Slack for production Wiser Task Schedulers to prevent exceptions during developing/testing to trigger it.
+
+                        // If there is a slackChannel and SlackAccessToken Send a slack message if critical error.
                         if (slackSettings != null && !String.IsNullOrWhiteSpace(slackSettings.SlackChannel) && !string.IsNullOrWhiteSpace(slackSettings.SlackAccessToken))
                         {
                             if (logLevel == logSettings.SlackLogLevel)
@@ -115,6 +118,7 @@ namespace WiserTaskScheduler.Core.Services
                                 await slack.Chat.PostMessage(new Message() { Text = $"Configuration : '{configurationName}'{Environment.NewLine}Time id : '{timeId}'{Environment.NewLine}order :{Environment.NewLine}message :{Environment.NewLine}{message}{Environment.NewLine}date : {DateTime.Now}",Channel=slackSettings.SlackChannel});
                             }    
                         }
+#endif
                     }
                     catch
                     {


### PR DESCRIPTION
Both channels can be used to notify multiple people when things go wrong. During development the chance that happens increases and the other people that are involved don't need to be updated about that.

https://app.asana.com/0/7257459017111/1203890701686050