### PR TITLE
Generate unique keys for replacements to prevent a key matching a value.

### DIFF
--- a/WiserTaskScheduler/WiserTaskScheduler/Core/Helpers/ReplacementHelper.cs
+++ b/WiserTaskScheduler/WiserTaskScheduler/Core/Helpers/ReplacementHelper.cs
@@ -77,7 +77,7 @@ namespace WiserTaskScheduler.Core.Helpers
                     }
                     else
                     {
-                        var parameterName = DatabaseHelpers.CreateValidParameterName(key);
+                        var parameterName = DatabaseHelpers.CreateValidParameterName($"{key}wts{Guid.NewGuid()}");
                         result = result.Replace($"[{{{originalKey}}}]", $"?{parameterName}");
                         insertedParameters.Add(new KeyValuePair<string, string>(parameterName, value));
                     }
@@ -97,18 +97,19 @@ namespace WiserTaskScheduler.Core.Helpers
                     }
                     else
                     {
-                        var parameterName = DatabaseHelpers.CreateValidParameterName(key);
+                        var parameterName = DatabaseHelpers.CreateValidParameterName($"{key}wts{Guid.NewGuid()}");
                         result = result.Replace($"[{{{originalKey}}}]", $"?{parameterName}");
                         insertedParameters.Add(new KeyValuePair<string, string>(parameterName, value));
                     }
                 }
                 else
                 {
-                    var parameterName = DatabaseHelpers.CreateValidParameterName(key);
+                    var parameterName = DatabaseHelpers.CreateValidParameterName($"{key}wts{Guid.NewGuid()}");
                     result = result.Replace($"[{{{originalKey}}}]", $"?{parameterName}");
                     parameterKeys.Add(new ParameterKeyModel()
                     {
                         Key = key,
+                        ReplacementKey = parameterName,
                         Hash = hashValue
                     });
                 }
@@ -175,8 +176,7 @@ namespace WiserTaskScheduler.Core.Helpers
                     value = StringHelpers.HashValue(value, hashSettings);
                 }
                 
-                var parameterName = DatabaseHelpers.CreateValidParameterName(key);
-                result = result.Replace($"?{parameterName}", value);
+                result = result.Replace($"?{parameterKey.ReplacementKey}", value);
             }
 
             return result;

--- a/WiserTaskScheduler/WiserTaskScheduler/Core/Models/ParameterKeyModel.cs
+++ b/WiserTaskScheduler/WiserTaskScheduler/Core/Models/ParameterKeyModel.cs
@@ -6,6 +6,11 @@ public class ParameterKeyModel
     /// Gets or sets the key for the parameter.
     /// </summary>
     public string Key { get; set; }
+    
+    /// <summary>
+    /// Gets or sets the key to use for replacements.
+    /// </summary>
+    public string ReplacementKey { get; set; }
 
     /// <summary>
     /// Gets or sets if the value needs to be provided as a hash.

--- a/WiserTaskScheduler/WiserTaskScheduler/Modules/Queries/Services/QueriesService.cs
+++ b/WiserTaskScheduler/WiserTaskScheduler/Modules/Queries/Services/QueriesService.cs
@@ -186,7 +186,6 @@ namespace WiserTaskScheduler.Modules.Queries.Services
 
             foreach (var parameterKey in parameterKeys)
             {
-                var parameterName = DatabaseHelpers.CreateValidParameterName(parameterKey.Key);
                 var value = ReplacementHelper.GetValue(parameterKey.Key, rows, (JObject)usingResultSet[rows[0]], false);
 
                 if (parameterKey.Hash)
@@ -194,7 +193,7 @@ namespace WiserTaskScheduler.Modules.Queries.Services
                     value = StringHelpers.HashValue(value, query.HashSettings);
                 }
                 
-                parameters.Add(new KeyValuePair<string, string>(parameterName, value));
+                parameters.Add(new KeyValuePair<string, string>(parameterKey.ReplacementKey, value));
             }
 
             databaseConnection.ClearParameters();


### PR DESCRIPTION
Keys for replacement where added with just a question mark in front. This could cause problems, such as in a query string of an URL if the key matches the query paramater. This makes the replacement value with a random part.

https://app.asana.com/0/7257459017111/1203072017496981