### PR TITLE
Added logic snippets support

### DIFF
--- a/WiserTaskScheduler/WiserTaskScheduler/Modules/Body/Models/BodyPartModel.cs
+++ b/WiserTaskScheduler/WiserTaskScheduler/Modules/Body/Models/BodyPartModel.cs
@@ -29,5 +29,10 @@ namespace WiserTaskScheduler.Modules.Body.Models
         /// Gets or sets if the body part needs to use the forced index.
         /// </summary>
         public bool ForceIndex { get; set; }
+
+        /// <summary>
+        /// Gets or sets whether the logic snippets (<c>[if]...[else]...[endif]</c>) should be evaluated. 
+        /// </summary>
+        public bool EvaluateLogicSnippets { get; set; }
     }
 }


### PR DESCRIPTION
The body parts can now evaluate logic snippets in the `<Text>` nodes by enabling the `EvaluateLogicSnippets` setting on the `<BodyPart>` node. It's disabled by default.

Asana: https://app.asana.com/0/5038781037429/1203762811573628