### PR TITLE
Allow default values for status code check

### DIFF
--- a/WiserTaskScheduler/WiserTaskScheduler/Core/Services/ConfigurationsService.cs
+++ b/WiserTaskScheduler/WiserTaskScheduler/Core/Services/ConfigurationsService.cs
@@ -247,7 +247,15 @@ namespace WiserTaskScheduler.Core.Services
 
                 try
                 {
-                    var statusCode = (string) ResultSetHelper.GetCorrectObject<JObject>($"{parts[0]}", ReplacementHelper.EmptyRows, resultSets)["StatusCode"];
+                    var defaultValue = String.Empty;
+                    var defaultValueIndex = parts[0].IndexOf('?');
+                    if (defaultValueIndex >= 0)
+                    {
+                        defaultValue = parts[0].Substring(defaultValueIndex);
+                        parts[0] = parts[0].Substring(0, defaultValueIndex);
+                    }
+
+                    var statusCode = ReplacementHelper.GetValue($"{parts[0]}.StatusCode{defaultValue}", ReplacementHelper.EmptyRows, resultSets, false);
                     
                     if (statusCode != parts[1])
                     {

--- a/WiserTaskScheduler/WiserTaskScheduler/Core/Services/ConfigurationsService.cs
+++ b/WiserTaskScheduler/WiserTaskScheduler/Core/Services/ConfigurationsService.cs
@@ -251,8 +251,8 @@ namespace WiserTaskScheduler.Core.Services
                     var defaultValueIndex = parts[0].IndexOf('?');
                     if (defaultValueIndex >= 0)
                     {
-                        defaultValue = parts[0].Substring(defaultValueIndex);
-                        parts[0] = parts[0].Substring(0, defaultValueIndex);
+                        defaultValue = parts[0][defaultValueIndex..];
+                        parts[0] = parts[0][..defaultValueIndex];
                     }
 
                     var statusCode = ReplacementHelper.GetValue($"{parts[0]}.StatusCode{defaultValue}", ReplacementHelper.EmptyRows, resultSets, false);
@@ -276,7 +276,15 @@ namespace WiserTaskScheduler.Core.Services
 
                 try
                 {
-                    var state = (string) ResultSetHelper.GetCorrectObject<JObject>($"{parts[0]}", ReplacementHelper.EmptyRows, resultSets)["Success"];
+                    var defaultValue = String.Empty;
+                    var defaultValueIndex = parts[0].IndexOf('?');
+                    if (defaultValueIndex >= 0)
+                    {
+                        defaultValue = parts[0][defaultValueIndex..];
+                        parts[0] = parts[0][..defaultValueIndex];
+                    }
+
+                    var state = ReplacementHelper.GetValue($"{parts[0]}.Success{defaultValue}", ReplacementHelper.EmptyRows, resultSets, false);
                     
                     if (state != parts[1])
                     {


### PR DESCRIPTION
The `OnlyWithStatusCode` setting now supports the use of default values.

Asana: https://app.asana.com/0/5038781037429/1203762811573628