### PR TITLE
Add the IgnoreSSLValidationErrors option to the HttpApi

### DIFF
--- a/WiserTaskScheduler/WiserTaskScheduler/Modules/HttpApis/Models/HttpApiModel.cs
+++ b/WiserTaskScheduler/WiserTaskScheduler/Modules/HttpApis/Models/HttpApiModel.cs
@@ -34,6 +34,11 @@ namespace WiserTaskScheduler.Modules.HttpApis.Models
         /// If false the using result set needs to be set to an array.
         /// </summary>
         public bool SingleRequest { get; set; } = true;
+        
+        /// <summary>
+        /// If True the connection will 'ignore' ssl validation errors
+        /// </summary>
+        public bool IgnoreSSLValidationErrors { get; set; } = false;
 
         /// <summary>
         /// Gets or sets the property of a response from which the next URL is taken.

--- a/WiserTaskScheduler/WiserTaskScheduler/Modules/HttpApis/Services/HttpApisService.cs
+++ b/WiserTaskScheduler/WiserTaskScheduler/Modules/HttpApis/Services/HttpApisService.cs
@@ -191,7 +191,17 @@ namespace WiserTaskScheduler.Modules.HttpApis.Services
                 };
             }
 
-            using var client = new HttpClient();
+            
+            var httpHandler = new HttpClientHandler();
+
+            if (httpApi.IgnoreSSLValidationErrors)
+            {
+                httpHandler.ClientCertificateOptions = ClientCertificateOption.Manual;
+                httpHandler.ServerCertificateCustomValidationCallback = (sender, cert, chain, sslPolicyErrors) => true;
+            }
+
+            using var client = new HttpClient(httpHandler);
+
             using var response = await client.SendAsync(request);
 
             // If the request was unauthorized retry the request if it has an OAuth API name set and it hasn't retried before.


### PR DESCRIPTION
needed for asana ticket: https://app.asana.com/0/1200923549887805/1204655966379800/f

to serve as a work-around case when clients don't have their certification setup correctly

Ran into this issue when working for one of our clients, the proper way is ofcourse to not have ssl validation errors however having this option makes it possible to continue working while this is dealt with by the costumer
