### PR TITLE
Change the moment the WTS writes to Slack it has started.

### DIFF
--- a/WiserTaskScheduler/WiserTaskScheduler/Core/Workers/MainWorker.cs
+++ b/WiserTaskScheduler/WiserTaskScheduler/Core/Workers/MainWorker.cs
@@ -41,13 +41,13 @@ namespace WiserTaskScheduler.Core.Workers
             this.slackChatService = slackChatService;
 
             this.mainService.LogSettings = RunScheme.LogSettings;
+
+            slackChatService.SendChannelMessageAsync("*Wiser Task Scheduler has started*");
         }
-        
 
         /// <inheritdoc />
         protected override async Task ExecuteActionAsync()
         {
-            slackChatService.SendChannelMessageAsync("*Wiser Task Scheduler has started*");
             await mainService.ManageConfigurations();
         }
 


### PR DESCRIPTION
The message was send when loading the configurations. But since this is a repeated process it kept sending the message.

https://app.asana.com/0/7257459017111/1204495804970023