### PR TITLE
Feature/limit sending errors

### DIFF
--- a/WiserTaskScheduler/WiserTaskScheduler/Core/Interfaces/ISlackChatService.cs
+++ b/WiserTaskScheduler/WiserTaskScheduler/Core/Interfaces/ISlackChatService.cs
@@ -11,9 +11,10 @@ namespace WiserTaskScheduler.Core.Interfaces
         /// Function to send a message to the specified recipient
         /// </summary>
         /// <param name="message">The message to be send.</param>
-        /// <param name="replies">(Optional)An array of messages that will be added to the message thread.</param>
-        /// <param name="recipient">(Optional)The target for the message, If not provided the one from the settings file will be used</param>
+        /// <param name="replies">(Optional) An array of messages that will be added to the message thread.</param>
+        /// <param name="recipient">(Optional) The target for the message, If not provided the one from the settings file will be used</param>
+        /// <param name="messageHash">(Optional) A hash to check if the message was already send within a given time. If not provided the message will always be sent.</param>
         /// <returns></returns>
-        Task SendChannelMessageAsync(string message, string[] replies = null, string recipient = null);
+        Task SendChannelMessageAsync(string message, string[] replies = null, string recipient = null, string messageHash = null);
     }
 }

--- a/WiserTaskScheduler/WiserTaskScheduler/Core/Models/WtsSettings.cs
+++ b/WiserTaskScheduler/WiserTaskScheduler/Core/Models/WtsSettings.cs
@@ -48,6 +48,11 @@ namespace WiserTaskScheduler.Core.Models
         public string ServiceFailedNotificationEmails { get; set; }
         
         /// <summary>
+        /// The number of minutes to wait before sending the same error notification again.
+        /// </summary>
+        public int ErrorNotificationsIntervalInMinutes { get; set; } = 60;
+        
+        /// <summary>
         /// Gets or sets the credentials from the secrets app settings.
         /// </summary>
         public IReadOnlyDictionary<string, string> Credentials { get; set; }

--- a/WiserTaskScheduler/WiserTaskScheduler/Core/Services/ErrorNotificationService.cs
+++ b/WiserTaskScheduler/WiserTaskScheduler/Core/Services/ErrorNotificationService.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -22,12 +23,17 @@ public class ErrorNotificationService : IErrorNotificationService, ISingletonSer
     private readonly IServiceProvider serviceProvider;
     private readonly ILogService logService;
     private readonly ILogger<ErrorNotificationService> logger;
+    private readonly WtsSettings wtsSettings;
+    
+    private ConcurrentDictionary<string, DateTime> sendNotifications;
 
-    public ErrorNotificationService(IServiceProvider serviceProvider, ILogService logService, ILogger<ErrorNotificationService> logger)
+    public ErrorNotificationService(IServiceProvider serviceProvider, ILogService logService, ILogger<ErrorNotificationService> logger, IOptions<WtsSettings> wtsSettings)
     {
         this.serviceProvider = serviceProvider;
         this.logService = logService;
         this.logger = logger;
+        this.wtsSettings = wtsSettings.Value;
+        sendNotifications = new ConcurrentDictionary<string, DateTime>();
     }
     
     /// <inheritdoc />
@@ -40,6 +46,19 @@ public class ErrorNotificationService : IErrorNotificationService, ISingletonSer
         {
             return;
         }
+        
+        // Generate SHA 256 based on configuration name, time id, order id and message
+        var sha256 = System.Security.Cryptography.SHA256.Create();
+        var hash = sha256.ComputeHash(System.Text.Encoding.UTF8.GetBytes($"{configurationName}{subject}{content}"));
+        var notificationHash = string.Join("", hash.Select(b => b.ToString("x2")));
+        
+        // If the notification has been sent within the set interval time, don't send it again. 30 seconds are added as a buffer.
+        if (sendNotifications.TryGetValue(notificationHash, out var lastSendDate) && lastSendDate > DateTime.Now.AddMinutes(-wtsSettings.ErrorNotificationsIntervalInMinutes).AddSeconds(30))
+        {
+            return;
+        }
+
+        sendNotifications.AddOrUpdate(notificationHash, DateTime.Now, (key, oldValue) => DateTime.Now);
 
         var emailList = emails.Split(";").ToList();
         await NotifyOfErrorByEmailAsync(emailList, subject, content, logSettings, logScope, configurationName);

--- a/WiserTaskScheduler/WiserTaskScheduler/Core/Services/ErrorNotificationService.cs
+++ b/WiserTaskScheduler/WiserTaskScheduler/Core/Services/ErrorNotificationService.cs
@@ -48,7 +48,7 @@ public class ErrorNotificationService : IErrorNotificationService, ISingletonSer
         }
         
         // Generate SHA 256 based on configuration name, time id, order id and message
-        var sha256 = System.Security.Cryptography.SHA256.Create();
+        using var sha256 = System.Security.Cryptography.SHA256.Create();
         var hash = sha256.ComputeHash(System.Text.Encoding.UTF8.GetBytes($"{configurationName}{subject}{content}"));
         var notificationHash = string.Join("", hash.Select(b => b.ToString("x2")));
         

--- a/WiserTaskScheduler/WiserTaskScheduler/Core/Services/LogService.cs
+++ b/WiserTaskScheduler/WiserTaskScheduler/Core/Services/LogService.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using GeeksCoreLibrary.Core.DependencyInjection.Interfaces;
 using GeeksCoreLibrary.Core.Models;
@@ -118,7 +119,12 @@ Order: '{order}'
 Message:
 {title}";
 
-                            await slackChatService.SendChannelMessageAsync(slackMessage,new[] { message });
+                            // Generate SHA 256 based on configuration name, time id, order id and message
+                            var sha256 = System.Security.Cryptography.SHA256.Create();
+                            var hash = sha256.ComputeHash(System.Text.Encoding.UTF8.GetBytes($"{configurationName}{timeId}{order}{message}"));
+                            var messageHash = string.Join("", hash.Select(b => b.ToString("x2")));
+                            
+                            await slackChatService.SendChannelMessageAsync(slackMessage,new[] { message },  messageHash: messageHash);
                         }
                     }
                     catch

--- a/WiserTaskScheduler/WiserTaskScheduler/Core/Services/LogService.cs
+++ b/WiserTaskScheduler/WiserTaskScheduler/Core/Services/LogService.cs
@@ -111,8 +111,9 @@ namespace WiserTaskScheduler.Core.Services
                         // log to slack chat service in case configured 
                         if (logLevel >= logSettings.SlackLogLevel)
                         {
-                            var title = message.Substring(0, message.IndexOf(Environment.NewLine));
-                            string slackMessage = $@"Log level: {logLevel}
+                            var linebreakIndex = message.IndexOf(Environment.NewLine, StringComparison.InvariantCulture);
+                            var title = linebreakIndex >= 0 ? message.Substring(0, linebreakIndex) : message;
+                            var slackMessage = $@"Log level: {logLevel}
 Configuration : '{configurationName}'
 Time ID: '{timeId}'
 Order: '{order}'

--- a/WiserTaskScheduler/WiserTaskScheduler/Core/Services/LogService.cs
+++ b/WiserTaskScheduler/WiserTaskScheduler/Core/Services/LogService.cs
@@ -121,7 +121,7 @@ Message:
 {title}";
 
                             // Generate SHA 256 based on configuration name, time id, order id and message
-                            var sha256 = System.Security.Cryptography.SHA256.Create();
+                            using var sha256 = System.Security.Cryptography.SHA256.Create();
                             var hash = sha256.ComputeHash(System.Text.Encoding.UTF8.GetBytes($"{configurationName}{timeId}{order}{message}"));
                             var messageHash = string.Join("", hash.Select(b => b.ToString("x2")));
                             


### PR DESCRIPTION
Add interval between error messages to prevent configurations that fail every minute for example to cause an overload of messages.

https://app.asana.com/0/7257459017111/1204645012777366