### PR TITLE
Cleanup render times tables.

### DIFF
--- a/WiserTaskScheduler/WiserTaskScheduler/Core/Models/Cleanup/CleanupServiceSettings.cs
+++ b/WiserTaskScheduler/WiserTaskScheduler/Core/Models/Cleanup/CleanupServiceSettings.cs
@@ -20,6 +20,16 @@ namespace WiserTaskScheduler.Core.Models.Cleanup
         /// Gets or sets if the logs table needs to be optimized after it has been cleaned.
         /// </summary>
         public bool OptimizeLogsTableAfterCleanup { get; set; } = true;
+        
+        /// <summary>
+        /// Gets or sets the number of days render times need to be kept.
+        /// </summary>
+        public int NumberOfDaysToStoreRenderTimes { get; set; } = 14;
+        
+        /// <summary>
+        /// Gets or sets if the render times tables needs to be optimized after they have been cleaned.
+        /// </summary>
+        public bool OptimizeRenderTimesTableAfterCleanup { get; set; } = true;
 
         /// <summary>
         /// Gets or sets the run scheme for the <see cref="CleanupWorker"/>.


### PR DESCRIPTION
If the render times for templates and dynamic contents are logged they need to be cleaned to ensure the database is not filled with the logs. On high traffic websites this can go fast, therefor the days to store has its own setting.

https://app.asana.com/0/7257459017111/1204505225976506