### PR TITLE
JWT token payload for OAuth2

### DIFF
--- a/WiserTaskScheduler/WiserTaskScheduler/Core/Models/OAuth/ClaimModel.cs
+++ b/WiserTaskScheduler/WiserTaskScheduler/Core/Models/OAuth/ClaimModel.cs
@@ -1,0 +1,29 @@
+﻿using System.ComponentModel.DataAnnotations;
+using System.Xml.Serialization;
+
+namespace WiserTaskScheduler.Core.Models.OAuth;
+
+/// <summary>
+/// Represents a claim for a JWT token.
+/// </summary>
+[XmlType("Claim")]
+public class ClaimModel
+{
+    /// <summary>
+    /// Gets or sets the name of the claim.
+    /// </summary>
+    [Required]
+    public string Name { get; set; }
+
+    /// <summary>
+    /// Gets or sets the value of the claim.
+    /// </summary>
+    [Required]
+    public string Value { get; set; }
+
+    /// <summary>
+    /// The data type of the value.
+    /// </summary>
+    [XmlAttribute(DataType = "string")]
+    public string DataType { get; set; }
+}

--- a/WiserTaskScheduler/WiserTaskScheduler/Core/Models/OAuth/OAuthJwtModel.cs
+++ b/WiserTaskScheduler/WiserTaskScheduler/Core/Models/OAuth/OAuthJwtModel.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Xml.Serialization;
+
+namespace WiserTaskScheduler.Core.Models.OAuth;
+
+/// <summary>
+/// Settings model to build the JWT token with.
+/// </summary>
+[XmlType("Jwt")]
+public class OAuthJwtModel
+{
+    /// <summary>
+    /// Gets or sets the expiry time of the token in seconds. Needed for the exp claim.
+    /// </summary>
+    public int ExpirationTime { get; set; } = 600;
+
+    /// <summary>
+    /// Gets or sets the issuer of the token. Needed for the iss claim.
+    /// </summary>
+    public string Issuer { get; set; }
+
+    /// <summary>
+    /// Gets or sets the subject of the token. Needed for the sub claim.
+    /// </summary>
+    public string Subject { get; set; }
+
+    /// <summary>
+    /// Gets or sets the audience of the token. Needed for the aud claim.
+    /// </summary>
+    public string Audience { get; set; }
+
+    /// <summary>
+    /// Gets or sets the location of the certificate to use.
+    /// </summary>
+    public string CertificateLocation { get; set; }
+
+    /// <summary>
+    /// Gets or sets the password of the certificate.
+    /// </summary>
+    public string CertificatePassword { get; set; }
+
+    /// <summary>
+    /// Gets or sets additional claims to add to the token.
+    /// </summary>
+    [XmlArray("Claims")]
+    [XmlArrayItem(typeof(ClaimModel))]
+    public ClaimModel[] Claims { get; set; } = Array.Empty<ClaimModel>();
+}

--- a/WiserTaskScheduler/WiserTaskScheduler/Core/Models/OAuth/OAuthModel.cs
+++ b/WiserTaskScheduler/WiserTaskScheduler/Core/Models/OAuth/OAuthModel.cs
@@ -59,6 +59,12 @@ namespace WiserTaskScheduler.Core.Models.OAuth
         public FormKeyValueModel[] FormKeyValues { get; set; }
 
         /// <summary>
+        /// Gets or sets the JWT settings for the OAuth payload.
+        /// </summary>
+        [XmlElement("Jwt")]
+        public OAuthJwtModel OAuthJwt { get; set; }
+
+        /// <summary>
         /// Gets or sets the access token.
         /// </summary>
         [XmlIgnore]

--- a/WiserTaskScheduler/WiserTaskScheduler/Modules/HttpApis/Models/HttpApiModel.cs
+++ b/WiserTaskScheduler/WiserTaskScheduler/Modules/HttpApis/Models/HttpApiModel.cs
@@ -30,6 +30,11 @@ namespace WiserTaskScheduler.Modules.HttpApis.Models
         public string OAuth { get; set; }
 
         /// <summary>
+        /// Gets or sets the JWT service to get the access token from.
+        /// </summary>
+        public string Jwt { get; set; }
+
+        /// <summary>
         /// Gets or sets if the HTTP API request needs to be requested once or more.
         /// If false the using result set needs to be set to an array.
         /// </summary>

--- a/WiserTaskScheduler/WiserTaskScheduler/WiserTaskScheduler.csproj
+++ b/WiserTaskScheduler/WiserTaskScheduler/WiserTaskScheduler.csproj
@@ -15,6 +15,7 @@
 
   <ItemGroup>
     <PackageReference Include="GeeksCoreLibrary" Version="3.0.21" />
+    <PackageReference Include="jose-jwt" Version="4.1.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.1" />
     <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="7.0.0" />
     <PackageReference Include="Serilog.AspNetCore" Version="6.1.0" />


### PR DESCRIPTION
Added option to generate a JWT token to use in the form values payload. If JWT settings are provided, the "grant_type", "username", "password" and "refresh_token" keys are not added, as the JWT token contains all the relevant data to authenticate. Note: The current implementation is based on how Adobe uses it.

[Asana ticket](https://app.asana.com/0/1199894242406919/1204012232897796)