### PR TITLE
Add table copy rules to exclude specific tables.

### DIFF
--- a/WiserTaskScheduler/AutoUpdater/AutoUpdater.csproj
+++ b/WiserTaskScheduler/AutoUpdater/AutoUpdater.csproj
@@ -12,7 +12,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="GeeksCoreLibrary" Version="3.0.21" />
+        <PackageReference Include="GeeksCoreLibrary" Version="3.0.25" />
         <PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.1" />
         <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="7.0.0" />
         <PackageReference Include="Serilog.AspNetCore" Version="6.1.0" />

--- a/WiserTaskScheduler/WiserTaskScheduler/Modules/Branches/Enums/CopyTypes.cs
+++ b/WiserTaskScheduler/WiserTaskScheduler/Modules/Branches/Enums/CopyTypes.cs
@@ -1,0 +1,13 @@
+﻿namespace WiserTaskScheduler.Modules.Branches.Enums;
+
+public enum CopyTypes
+{
+    /// <summary>
+    /// Fully skip the given table.
+    /// </summary>
+    Nothing,
+    /// <summary>
+    /// Copy the structure of the table but not its data.
+    /// </summary>
+    Structure
+}

--- a/WiserTaskScheduler/WiserTaskScheduler/Modules/Branches/Models/BranchQueueModel.cs
+++ b/WiserTaskScheduler/WiserTaskScheduler/Modules/Branches/Models/BranchQueueModel.cs
@@ -38,5 +38,12 @@ namespace WiserTaskScheduler.Modules.Branches.Models
         /// This is for sending notifications about the status of the deletion of a branch.
         /// </summary>
         public ulong DeletedBranchTemplateId { get; set; }
+        
+        /// <summary>
+        /// Gets or sets the specific rules for copying tables.
+        /// </summary>
+        [XmlArray("CopyTableRules")]
+        [XmlArrayItem(typeof(CopyTableRuleModel))]
+        public CopyTableRuleModel[] CopyTableRules { get; set; }
     }
 }

--- a/WiserTaskScheduler/WiserTaskScheduler/Modules/Branches/Models/CopyTableRuleModel.cs
+++ b/WiserTaskScheduler/WiserTaskScheduler/Modules/Branches/Models/CopyTableRuleModel.cs
@@ -1,0 +1,18 @@
+﻿using System.Xml.Serialization;
+using WiserTaskScheduler.Modules.Branches.Enums;
+
+namespace WiserTaskScheduler.Modules.Branches.Models;
+
+[XmlType("CopyTableRule")]
+public class CopyTableRuleModel
+{
+    /// <summary>
+    /// Gets or sets the name of the table to set the specific copy rules for.
+    /// </summary>
+    public string TableName { get; set; }
+
+    /// <summary>
+    /// Gets or sets the specific copy rules for the table.
+    /// </summary>
+    public CopyTypes CopyType { get; set; } = CopyTypes.Structure;
+}

--- a/WiserTaskScheduler/WiserTaskScheduler/Modules/Branches/Services/BranchQueueService.cs
+++ b/WiserTaskScheduler/WiserTaskScheduler/Modules/Branches/Services/BranchQueueService.cs
@@ -227,10 +227,10 @@ ORDER BY TABLE_NAME ASC";
                             
                             // Check if the structure of the table is excluded from the creation of the branch.
                             if (branchQueue.CopyTableRules.Any(t => t.CopyType == CopyTypes.Nothing && (
-                                                                (t.TableName.StartsWith('%') && t.TableName.EndsWith('%') && tableName.Contains(t.TableName.Substring(1, t.TableName.Length - 2), StringComparison.InvariantCultureIgnoreCase))
-                                                                || (t.TableName.StartsWith('%') && tableName.EndsWith(t.TableName.Substring(1), StringComparison.InvariantCultureIgnoreCase))
-                                                                || (t.TableName.EndsWith('%') && tableName.StartsWith(t.TableName.Substring(0, t.TableName.Length - 1), StringComparison.InvariantCultureIgnoreCase))
-                                                                || tableName.Equals(t.TableName, StringComparison.InvariantCultureIgnoreCase)
+                                                                (t.TableName.StartsWith('%') && t.TableName.EndsWith('%') && tableName.Contains(t.TableName.Substring(1, t.TableName.Length - 2), StringComparison.OrdinalIgnoreCase))
+                                                                || (t.TableName.StartsWith('%') && tableName.EndsWith(t.TableName.Substring(1), StringComparison.OrdinalIgnoreCase))
+                                                                || (t.TableName.EndsWith('%') && tableName.StartsWith(t.TableName.Substring(0, t.TableName.Length - 1), StringComparison.OrdinalIgnoreCase))
+                                                                || tableName.Equals(t.TableName, StringComparison.OrdinalIgnoreCase)
                                                             )))
                             {
                                 continue;
@@ -463,10 +463,10 @@ JOIN `{branchDatabase}`.`{prefix}{WiserTableNames.WiserItem}` AS item ON item.id
                     }
 
                     // Don't copy data from tables that have specific rules. Either the table needs to stay empty or it does not exist in the new branch.
-                    if (branchQueue.CopyTableRules.Any(t => (t.TableName.StartsWith('%') && t.TableName.EndsWith('%') && tableName.Contains(t.TableName.Substring(1, t.TableName.Length - 2), StringComparison.InvariantCultureIgnoreCase))
-                                                       || (t.TableName.StartsWith('%') && tableName.EndsWith(t.TableName.Substring(1), StringComparison.InvariantCultureIgnoreCase))
-                                                       || (t.TableName.EndsWith('%') && tableName.StartsWith(t.TableName.Substring(0, t.TableName.Length - 1), StringComparison.InvariantCultureIgnoreCase))
-                                                       || tableName.Equals(t.TableName, StringComparison.InvariantCultureIgnoreCase)
+                    if (branchQueue.CopyTableRules.Any(t => (t.TableName.StartsWith('%') && t.TableName.EndsWith('%') && tableName.Contains(t.TableName.Substring(1, t.TableName.Length - 2), StringComparison.OrdinalIgnoreCase))
+                                                       || (t.TableName.StartsWith('%') && tableName.EndsWith(t.TableName.Substring(1), StringComparison.OrdinalIgnoreCase))
+                                                       || (t.TableName.EndsWith('%') && tableName.StartsWith(t.TableName.Substring(0, t.TableName.Length - 1), StringComparison.OrdinalIgnoreCase))
+                                                       || tableName.Equals(t.TableName, StringComparison.OrdinalIgnoreCase)
                                                    ))
                     {
                         continue;

--- a/WiserTaskScheduler/WiserTaskScheduler/Modules/Branches/Services/BranchQueueService.cs
+++ b/WiserTaskScheduler/WiserTaskScheduler/Modules/Branches/Services/BranchQueueService.cs
@@ -24,6 +24,7 @@ using Newtonsoft.Json.Linq;
 using WiserTaskScheduler.Core.Enums;
 using WiserTaskScheduler.Core.Interfaces;
 using WiserTaskScheduler.Core.Models;
+using WiserTaskScheduler.Modules.Branches.Enums;
 using WiserTaskScheduler.Modules.Branches.Interfaces;
 using WiserTaskScheduler.Modules.Branches.Models;
 using WiserTaskScheduler.Modules.Wiser.Interfaces;
@@ -223,6 +224,17 @@ ORDER BY TABLE_NAME ASC";
                         foreach (DataRow dataRow in dataTable.Rows)
                         {
                             var tableName = dataRow.Field<string>("TABLE_NAME");
+                            
+                            // Check if the structure of the table is excluded from the creation of the branch.
+                            if (branchQueue.CopyTableRules.Any(t => t.CopyType == CopyTypes.Nothing && (
+                                                                (t.TableName.StartsWith('%') && t.TableName.EndsWith('%') && tableName.Contains(t.TableName.Substring(1, t.TableName.Length - 2), StringComparison.InvariantCultureIgnoreCase))
+                                                                || (t.TableName.StartsWith('%') && tableName.EndsWith(t.TableName.Substring(1), StringComparison.InvariantCultureIgnoreCase))
+                                                                || (t.TableName.EndsWith('%') && tableName.StartsWith(t.TableName.Substring(0, t.TableName.Length - 1), StringComparison.InvariantCultureIgnoreCase))
+                                                                || tableName.Equals(t.TableName, StringComparison.InvariantCultureIgnoreCase)
+                                                            )))
+                            {
+                                continue;
+                            }
 
                             command.CommandText = $"CREATE TABLE `{branchDatabase.ToMySqlSafeValue(false)}`.`{tableName.ToMySqlSafeValue(false)}` LIKE `{originalDatabase.ToMySqlSafeValue(false)}`.`{tableName.ToMySqlSafeValue(false)}`";
                             await command.ExecuteNonQueryAsync();
@@ -446,6 +458,16 @@ JOIN `{branchDatabase}`.`{prefix}{WiserTableNames.WiserItem}` AS item ON item.id
                         || tableName!.StartsWith("log_", StringComparison.OrdinalIgnoreCase)
                         || tableName.EndsWith("_log", StringComparison.OrdinalIgnoreCase)
                         || tableName.EndsWith(WiserTableNames.ArchiveSuffix))
+                    {
+                        continue;
+                    }
+
+                    // Don't copy data from tables that have specific rules. Either the table needs to stay empty or it does not exist in the new branch.
+                    if (branchQueue.CopyTableRules.Any(t => (t.TableName.StartsWith('%') && t.TableName.EndsWith('%') && tableName.Contains(t.TableName.Substring(1, t.TableName.Length - 2), StringComparison.InvariantCultureIgnoreCase))
+                                                       || (t.TableName.StartsWith('%') && tableName.EndsWith(t.TableName.Substring(1), StringComparison.InvariantCultureIgnoreCase))
+                                                       || (t.TableName.EndsWith('%') && tableName.StartsWith(t.TableName.Substring(0, t.TableName.Length - 1), StringComparison.InvariantCultureIgnoreCase))
+                                                       || tableName.Equals(t.TableName, StringComparison.InvariantCultureIgnoreCase)
+                                                   ))
                     {
                         continue;
                     }

--- a/WiserTaskScheduler/WiserTaskScheduler/WiserTaskScheduler.csproj
+++ b/WiserTaskScheduler/WiserTaskScheduler/WiserTaskScheduler.csproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="GeeksCoreLibrary" Version="3.0.21" />
+    <PackageReference Include="GeeksCoreLibrary" Version="3.0.25" />
     <PackageReference Include="jose-jwt" Version="4.1.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.1" />
     <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="7.0.0" />


### PR DESCRIPTION
Add copy rules for tables when creating a branch to prevent custom tables to be copied.

Tables can be completely ignored or only the structure can be created if it needs to exist to be able to run the branch.

https://app.asana.com/0/1205090868730163/1205282683097489