### PR TITLE
add timeout option to httpcalls

### DIFF
--- a/WiserTaskScheduler/WiserTaskScheduler/Modules/HttpApis/Models/HttpApiModel.cs
+++ b/WiserTaskScheduler/WiserTaskScheduler/Modules/HttpApis/Models/HttpApiModel.cs
@@ -41,6 +41,12 @@ namespace WiserTaskScheduler.Modules.HttpApis.Models
         public bool IgnoreSSLValidationErrors { get; set; } = false;
 
         /// <summary>
+        /// If set will override the timeout value of the request with the default which is 100 seconds
+        /// value is in seconds
+        /// </summary>
+        public int Timeout { get; set; } = -1;
+
+        /// <summary>
         /// Gets or sets the property of a response from which the next URL is taken.
         /// </summary>
         public string NextUrlProperty { get; set; }

--- a/WiserTaskScheduler/WiserTaskScheduler/Modules/HttpApis/Services/HttpApisService.cs
+++ b/WiserTaskScheduler/WiserTaskScheduler/Modules/HttpApis/Services/HttpApisService.cs
@@ -202,6 +202,11 @@ namespace WiserTaskScheduler.Modules.HttpApis.Services
 
             using var client = new HttpClient(httpHandler);
 
+            if (httpApi.Timeout >= 0)
+            {
+                client.Timeout = TimeSpan.FromSeconds(httpApi.Timeout);
+            }
+            
             using var response = await client.SendAsync(request);
 
             // If the request was unauthorized retry the request if it has an OAuth API name set and it hasn't retried before.


### PR DESCRIPTION
asana: no asana point
this is needed to resolve a issue with some httpapi calls taking longer then the default 100 seconds