### PR TITLE
Change the logging for the action validation.

### DIFF
--- a/WiserTaskScheduler/WiserTaskScheduler/Core/Services/ConfigurationsService.cs
+++ b/WiserTaskScheduler/WiserTaskScheduler/Core/Services/ConfigurationsService.cs
@@ -265,13 +265,13 @@ namespace WiserTaskScheduler.Core.Services
                     
                     if (statusCode != parts[1])
                     {
-                        await logService.LogInformation(logger, LogScopes.RunBody, LogSettings, $"Skipped action because status code was '{statusCode}'.", configurationServiceName, action.TimeId, action.Order);
+                        await logService.LogInformation(logger, LogScopes.RunStartAndStop, LogSettings, $"Skipped action because status code was '{statusCode}'.", configurationServiceName, action.TimeId, action.Order);
                         return true;
                     }
                 }
                 catch (Exception e)
                 {
-                    await logService.LogError(logger, LogScopes.RunBody, LogSettings, $"Failed to validate status code, skipping action. Exception: {e}", configurationServiceName, action.TimeId, action.Order);
+                    await logService.LogError(logger, LogScopes.RunStartAndStop, LogSettings, $"Failed to validate status code, skipping action. Exception: {e}", configurationServiceName, action.TimeId, action.Order);
                     return true;
                 }
             }
@@ -294,13 +294,13 @@ namespace WiserTaskScheduler.Core.Services
                     
                     if (state != parts[1])
                     {
-                        await logService.LogInformation(logger, LogScopes.RunBody, LogSettings, $"Skipped action because success state was '{state}'.", configurationServiceName, action.TimeId, action.Order);
+                        await logService.LogInformation(logger, LogScopes.RunStartAndStop, LogSettings, $"Skipped action because success state was '{state}'.", configurationServiceName, action.TimeId, action.Order);
                         return true;
                     }
                 }
                 catch (Exception e)
                 {
-                    await logService.LogError(logger, LogScopes.RunBody, LogSettings, $"Failed to validate action success, skipping action. Exception: {e}", configurationServiceName, action.TimeId, action.Order);
+                    await logService.LogError(logger, LogScopes.RunStartAndStop, LogSettings, $"Failed to validate action success, skipping action. Exception: {e}", configurationServiceName, action.TimeId, action.Order);
                     return true;
                 }
             }


### PR DESCRIPTION
The validation is used to determine if the action needs to be executed. It is therefore more logical to log it as the start and stop of the run instead of part of the body.

No ticket.