### PR TITLE
Added error handling around Wiser dashboard database calls

### DIFF
--- a/WiserTaskScheduler/WiserTaskScheduler/Core/Workers/BaseWorker.cs
+++ b/WiserTaskScheduler/WiserTaskScheduler/Core/Workers/BaseWorker.cs
@@ -113,17 +113,17 @@ namespace WiserTaskScheduler.Core.Workers
                     {
                         alreadyRunning = await wiserDashboardService.IsServiceRunning(ConfigurationName, RunScheme.TimeId);
                         paused = await wiserDashboardService.IsServicePaused(ConfigurationName, RunScheme.TimeId);
-                        // only save paused state if we know for sure it is paused and not currently running (if it is running, it will be set to paused by that thread after the execution)
+                        // Only save paused state if we know for sure it is paused and not currently running (if it is running, it will be set to paused by that thread after the execution).
                         if (paused.HasValue && paused.Value && alreadyRunning.HasValue && !alreadyRunning.Value)
                         {
                             await wiserDashboardService.UpdateServiceAsync(ConfigurationName, RunScheme.TimeId, state: "paused");
                         }
                     }
 
-                    // skip if already running or we don't know if it's running, except when we know the previous state sync failed
+                    // Skip if already running or we don't know if it's running, except when we know the previous state sync failed.
                     if ((alreadyRunning.HasValue && !alreadyRunning.Value) || !updateSucceeded)
                     {
-                        // also skip if paused, or we don't know if it's paused, except when it's a manual run
+                        // Also skip if paused, or we don't know if it's paused, except when it's a manual run.
                         if ((paused.HasValue && !paused.Value) || SingleRun)
                         {
                             await logService.LogInformation(logger, LogScopes.RunStartAndStop, RunScheme.LogSettings, $"{Name} started at: {DateTime.Now}", Name, RunScheme.TimeId);
@@ -144,7 +144,7 @@ namespace WiserTaskScheduler.Core.Workers
                             if (!String.IsNullOrWhiteSpace(ConfigurationName))
                             {
                                 paused = await wiserDashboardService.IsServicePaused(ConfigurationName, RunScheme.TimeId);
-                                // only set state to paused if we are sure it's paused
+                                // Only set state to paused if we are sure it's paused.
                                 if (paused.HasValue && paused.Value)
                                 {
                                     state = "paused";
@@ -152,7 +152,7 @@ namespace WiserTaskScheduler.Core.Workers
                                 else
                                 {
                                     var states = await wiserDashboardService.GetLogStatesFromLastRun(ConfigurationName, RunScheme.TimeId, runStartTime);
-                                    if (states == null) // exception occurred in getting states
+                                    if (states == null) // Exception occurred in getting states.
                                     {
                                         state = "unknown";
                                     }
@@ -166,7 +166,7 @@ namespace WiserTaskScheduler.Core.Workers
                                     }
                                 }
 
-                                // if storing the state of this run fails, the state will stay on "running", which will prevent any future runs, so keep track of the success
+                                // If storing the state of this run fails, the state will stay on "running", which will prevent any future runs, so keep track of the success.
                                 updateSucceeded = await wiserDashboardService.UpdateServiceAsync(ConfigurationName, RunScheme.TimeId, nextRun: runSchemesService.GetDateTimeTillNextRun(RunScheme), lastRun: DateTime.Now, runTime: stopWatch.Elapsed, state: state, extraRun: false);
                                 if (!updateSucceeded)
                                 {
@@ -183,7 +183,7 @@ namespace WiserTaskScheduler.Core.Workers
                     // If the configuration only needs to be run once break out of the while loop. State will not be set on stopped because the normal configuration is still active.
                     if (SingleRun)
                     {
-                        // if storing the result of this run failed the first time, try again now, otherwise the state will stay on running and it will never run again
+                        // If storing the result of this run failed the first time, try again now, otherwise the state will stay on running and it will never run again.
                         if (!updateSucceeded)
                         {
                             updateSucceeded = await wiserDashboardService.UpdateServiceAsync(ConfigurationName, RunScheme.TimeId, nextRun: runSchemesService.GetDateTimeTillNextRun(RunScheme), lastRun: DateTime.Now, runTime: stopWatch.Elapsed, state: state, extraRun: false);

--- a/WiserTaskScheduler/WiserTaskScheduler/Core/Workers/BaseWorker.cs
+++ b/WiserTaskScheduler/WiserTaskScheduler/Core/Workers/BaseWorker.cs
@@ -152,17 +152,17 @@ namespace WiserTaskScheduler.Core.Workers
                                 else
                                 {
                                     var states = await wiserDashboardService.GetLogStatesFromLastRun(ConfigurationName, RunScheme.TimeId, runStartTime);
-                                    if (states.Contains("Critical", StringComparer.OrdinalIgnoreCase) || states.Contains("Error", StringComparer.OrdinalIgnoreCase))
+                                    if (states == null) // exception occurred in getting states
+                                    {
+                                        state = "unknown";
+                                    }
+                                    else if (states.Contains("Critical", StringComparer.OrdinalIgnoreCase) || states.Contains("Error", StringComparer.OrdinalIgnoreCase))
                                     {
                                         state = "failed";
                                     }
                                     else if (states.Contains("Warning", StringComparer.OrdinalIgnoreCase))
                                     {
                                         state = "warning";
-                                    }
-                                    else if (states.Count == 0) // exception occurred in getting states
-                                    {
-                                        state = "unknown";
                                     }
                                 }
 

--- a/WiserTaskScheduler/WiserTaskScheduler/Core/Workers/BaseWorker.cs
+++ b/WiserTaskScheduler/WiserTaskScheduler/Core/Workers/BaseWorker.cs
@@ -101,24 +101,30 @@ namespace WiserTaskScheduler.Core.Workers
                     await WaitTillNextRun(stoppingToken);
                 }
 
+                var updateSucceeded = true;
                 while (!stoppingToken.IsCancellationRequested)
                 {
-                    var paused = false;
-                    var alreadyRunning = false;
+                    var state = "success";
+                    var stopWatch = new Stopwatch();
+                    bool? paused = false;
+                    bool? alreadyRunning = false;
                     
                     if (!String.IsNullOrWhiteSpace(ConfigurationName))
                     {
                         alreadyRunning = await wiserDashboardService.IsServiceRunning(ConfigurationName, RunScheme.TimeId);
                         paused = await wiserDashboardService.IsServicePaused(ConfigurationName, RunScheme.TimeId);
-                        if (paused && !alreadyRunning)
+                        // only save paused state if we know for sure it is paused and not currently running (if it is running, it will be set to paused by that thread after the execution)
+                        if (paused.HasValue && paused.Value && alreadyRunning.HasValue && !alreadyRunning.Value)
                         {
                             await wiserDashboardService.UpdateServiceAsync(ConfigurationName, RunScheme.TimeId, state: "paused");
                         }
                     }
 
-                    if (!alreadyRunning)
+                    // skip if already running or we don't know if it's running, except when we know the previous state sync failed
+                    if ((alreadyRunning.HasValue && !alreadyRunning.Value) || !updateSucceeded)
                     {
-                        if (!paused || SingleRun)
+                        // also skip if paused, or we don't know if it's paused, except when it's a manual run
+                        if ((paused.HasValue && !paused.Value) || SingleRun)
                         {
                             await logService.LogInformation(logger, LogScopes.RunStartAndStop, RunScheme.LogSettings, $"{Name} started at: {DateTime.Now}", Name, RunScheme.TimeId);
                             if (!String.IsNullOrWhiteSpace(ConfigurationName))
@@ -127,7 +133,6 @@ namespace WiserTaskScheduler.Core.Workers
                             }
 
                             var runStartTime = DateTime.Now;
-                            var stopWatch = new Stopwatch();
                             stopWatch.Start();
 
                             await ExecuteActionAsync();
@@ -138,23 +143,35 @@ namespace WiserTaskScheduler.Core.Workers
 
                             if (!String.IsNullOrWhiteSpace(ConfigurationName))
                             {
-                                var states = await wiserDashboardService.GetLogStatesFromLastRun(ConfigurationName, RunScheme.TimeId, runStartTime);
-
-                                var state = "success";
-                                if (await wiserDashboardService.IsServicePaused(ConfigurationName, RunScheme.TimeId))
+                                paused = await wiserDashboardService.IsServicePaused(ConfigurationName, RunScheme.TimeId);
+                                // only set state to paused if we are sure it's paused
+                                if (paused.HasValue && paused.Value)
                                 {
                                     state = "paused";
                                 }
-                                else if (states.Contains("Critical", StringComparer.OrdinalIgnoreCase) || states.Contains("Error", StringComparer.OrdinalIgnoreCase))
+                                else
                                 {
-                                    state = "failed";
-                                }
-                                else if (states.Contains("Warning", StringComparer.OrdinalIgnoreCase))
-                                {
-                                    state = "warning";
+                                    var states = await wiserDashboardService.GetLogStatesFromLastRun(ConfigurationName, RunScheme.TimeId, runStartTime);
+                                    if (states.Contains("Critical", StringComparer.OrdinalIgnoreCase) || states.Contains("Error", StringComparer.OrdinalIgnoreCase))
+                                    {
+                                        state = "failed";
+                                    }
+                                    else if (states.Contains("Warning", StringComparer.OrdinalIgnoreCase))
+                                    {
+                                        state = "warning";
+                                    }
+                                    else if (states.Count == 0) // exception occurred in getting states
+                                    {
+                                        state = "unknown";
+                                    }
                                 }
 
-                                await wiserDashboardService.UpdateServiceAsync(ConfigurationName, RunScheme.TimeId, nextRun: runSchemesService.GetDateTimeTillNextRun(RunScheme), lastRun: DateTime.Now, runTime: stopWatch.Elapsed, state: state, extraRun: false);
+                                // if storing the state of this run fails, the state will stay on "running", which will prevent any future runs, so keep track of the success
+                                updateSucceeded = await wiserDashboardService.UpdateServiceAsync(ConfigurationName, RunScheme.TimeId, nextRun: runSchemesService.GetDateTimeTillNextRun(RunScheme), lastRun: DateTime.Now, runTime: stopWatch.Elapsed, state: state, extraRun: false);
+                                if (!updateSucceeded)
+                                {
+                                    await errorNotificationService.NotifyOfErrorByEmailAsync(serviceFailedNotificationEmails, $"Service '{ConfigurationName ?? Name}'{(RunScheme.TimeId > 0 ? $" with time ID '{RunScheme.TimeId}'" : "")} of '{wtsSettings.Name}' status save failed.", $"Wiser Task Scheduler '{wtsSettings.Name}' failed to save the service '{ConfigurationName ?? Name}'{(RunScheme.TimeId > 0 ? $" with time ID '{RunScheme.TimeId}'" : "")} state of the last run, which is '{state}', to the database. The service will continue running and the next run will attempt a new state save. Until then, the service state in the database will be incorrect.", RunScheme.LogSettings, LogScopes.RunBody, ConfigurationName ?? Name);
+                                }
                             }
                         }
                         else
@@ -166,6 +183,16 @@ namespace WiserTaskScheduler.Core.Workers
                     // If the configuration only needs to be run once break out of the while loop. State will not be set on stopped because the normal configuration is still active.
                     if (SingleRun)
                     {
+                        // if storing the result of this run failed the first time, try again now, otherwise the state will stay on running and it will never run again
+                        if (!updateSucceeded)
+                        {
+                            updateSucceeded = await wiserDashboardService.UpdateServiceAsync(ConfigurationName, RunScheme.TimeId, nextRun: runSchemesService.GetDateTimeTillNextRun(RunScheme), lastRun: DateTime.Now, runTime: stopWatch.Elapsed, state: state, extraRun: false);
+                            if (!updateSucceeded)
+                            {
+                                await errorNotificationService.NotifyOfErrorByEmailAsync(serviceFailedNotificationEmails, $"Service '{ConfigurationName ?? Name}'{(RunScheme.TimeId > 0 ? $" with time ID '{RunScheme.TimeId}'" : "")} of '{wtsSettings.Name}' status save failed.", $"Wiser Task Scheduler '{wtsSettings.Name}' failed to save the service '{ConfigurationName ?? Name}'{(RunScheme.TimeId > 0 ? $" with time ID '{RunScheme.TimeId}'" : "")} state of the last run, which is '{state}', to the database a second time. Since this was a single run configuration, no more attempts will be made to correct this. The service state will now permanently be incorrect until it is manually updated.", RunScheme.LogSettings, LogScopes.RunStartAndStop, ConfigurationName ?? Name);
+                            }
+                        }
+
                         break;
                     }
 

--- a/WiserTaskScheduler/WiserTaskScheduler/Modules/Wiser/Interfaces/IWiserDashboardService.cs
+++ b/WiserTaskScheduler/WiserTaskScheduler/Modules/Wiser/Interfaces/IWiserDashboardService.cs
@@ -45,8 +45,8 @@ public interface IWiserDashboardService
     /// <param name="paused">Optional: The paused state of the service. Leave null to keep the current value.</param>
     /// <param name="extraRun">Optional: If the service need to be run an extra time. Leave null to keep the current value.</param>
     /// <param name="templateId">Optional: The ID of the template that of the service</param>
-    /// <returns></returns>
-    Task UpdateServiceAsync(string configuration, int timeId, string action = null, string scheme = null, DateTime? lastRun = null, DateTime? nextRun = null, TimeSpan? runTime = null, string state = null, bool? paused = null, bool? extraRun = null, int templateId = -1);
+    /// <returns>Returns if the update succeeded.</returns>
+    Task<bool> UpdateServiceAsync(string configuration, int timeId, string action = null, string scheme = null, DateTime? lastRun = null, DateTime? nextRun = null, TimeSpan? runTime = null, string state = null, bool? paused = null, bool? extraRun = null, int templateId = -1);
 
     /// <summary>
     /// Get the unique states that logs have been written to since a certain time for a run scheme.
@@ -54,7 +54,7 @@ public interface IWiserDashboardService
     /// <param name="configuration">The name of the configuration.</param>
     /// <param name="timeId">The time ID of the run scheme.</param>
     /// <param name="runStartTime">The datetime the run scheme started.</param>
-    /// <returns></returns>
+    /// <returns>A list with all unique result states</returns>
     Task<List<string>> GetLogStatesFromLastRun(string configuration, int timeId, DateTime runStartTime);
 
     /// <summary>
@@ -62,14 +62,14 @@ public interface IWiserDashboardService
     /// </summary>
     /// <param name="configuration">The name of the configuration.</param>
     /// <param name="timeId">The time ID of the run scheme.</param>
-    /// <returns></returns>
-    Task<bool> IsServicePaused(string configuration, int timeId);
+    /// <returns>If the service is currently paused, null if call failed</returns>
+    Task<bool?> IsServicePaused(string configuration, int timeId);
 
     /// <summary>
-    /// Check if the service is already running.
+    /// Check if the service currently has the "running" state.
     /// </summary>
     /// <param name="configuration">The name of the configuration.</param>
     /// <param name="timeId">The time ID of the run scheme.</param>
-    /// <returns></returns>
-    Task<bool> IsServiceRunning(string configuration, int timeId);
+    /// <returns>If the service is currently running, null if call failed</returns>
+    Task<bool?> IsServiceRunning(string configuration, int timeId);
 }

--- a/WiserTaskScheduler/WiserTaskScheduler/Modules/Wiser/Services/WiserDashboardService.cs
+++ b/WiserTaskScheduler/WiserTaskScheduler/Modules/Wiser/Services/WiserDashboardService.cs
@@ -4,10 +4,14 @@ using System.Data;
 using System.Linq;
 using System.Threading.Tasks;
 using WiserTaskScheduler.Modules.Wiser.Interfaces;
+using WiserTaskScheduler.Core.Interfaces;
+using WiserTaskScheduler.Core.Enums;
+using WiserTaskScheduler.Core.Models;
 using GeeksCoreLibrary.Core.DependencyInjection.Interfaces;
 using GeeksCoreLibrary.Core.Models;
 using GeeksCoreLibrary.Modules.Databases.Interfaces;
 using GeeksCoreLibrary.Modules.WiserDashboard.Models;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace WiserTaskScheduler.Modules.Wiser.Services;
@@ -15,10 +19,16 @@ namespace WiserTaskScheduler.Modules.Wiser.Services;
 public class WiserDashboardService : IWiserDashboardService, ISingletonService
 {
     private readonly IServiceProvider serviceProvider;
+    private readonly ILogService logService;
+    private readonly ILogger<WiserDashboardService> logger;
+    private readonly LogSettings logSettings;
 
-    public WiserDashboardService(IServiceProvider serviceProvider)
+    public WiserDashboardService(IServiceProvider serviceProvider, ILogService logService, ILogger<WiserDashboardService> logger)
     {
         this.serviceProvider = serviceProvider;
+        this.logService = logService;
+        this.logger = logger;
+        this.logSettings = new LogSettings();
     }
     
     /// <inheritdoc />
@@ -70,7 +80,7 @@ FROM {WiserTableNames.WtsServices}
     }
 
     /// <inheritdoc />
-    public async Task UpdateServiceAsync(string configuration, int timeId, string action = null, string scheme = null, DateTime? lastRun = null, DateTime? nextRun = null, TimeSpan? runTime = null, string state = null, bool? paused = null, bool? extraRun = null, int templateId = -1)
+    public async Task<bool> UpdateServiceAsync(string configuration, int timeId, string action = null, string scheme = null, DateTime? lastRun = null, DateTime? nextRun = null, TimeSpan? runTime = null, string state = null, bool? paused = null, bool? extraRun = null, int templateId = -1)
     {
         var querySetParts = new List<string>();
         var parameters = new Dictionary<string, object>()
@@ -129,7 +139,7 @@ FROM {WiserTableNames.WtsServices}
 
         if (!querySetParts.Any())
         {
-            return;
+            return true;
         }
 
         if (templateId >= 0)
@@ -138,8 +148,18 @@ FROM {WiserTableNames.WtsServices}
             parameters.Add("templateId", templateId);
         }
 
-        var query = $"UPDATE {WiserTableNames.WtsServices} SET {String.Join(',', querySetParts)} WHERE configuration = ?configuration AND time_id = ?timeId";
-        await ExecuteQueryAsync(query, parameters);
+        try
+        {
+            var query = $"UPDATE {WiserTableNames.WtsServices} SET {String.Join(',', querySetParts)} WHERE configuration = ?configuration AND time_id = ?timeId";
+            await ExecuteQueryAsync(query, parameters);
+        }
+        catch (Exception e)
+        {
+            await logService.LogError(logger, LogScopes.RunBody, logSettings, $"{configuration} failed updating service status to {state} with exception {e}", configuration, timeId);
+            return false;
+        }
+
+        return true;
     }
 
     /// <summary>
@@ -200,65 +220,86 @@ FROM {WiserTableNames.WtsServices}
     public async Task<List<string>> GetLogStatesFromLastRun(string configuration, int timeId, DateTime runStartTime)
     {
         var states = new List<string>();
-        
-        using var scope = serviceProvider.CreateScope();
-        await using var databaseConnection = scope.ServiceProvider.GetRequiredService<IDatabaseConnection>();
+        try
+        {
+            using var scope = serviceProvider.CreateScope();
+            await using var databaseConnection = scope.ServiceProvider.GetRequiredService<IDatabaseConnection>();
 
-        databaseConnection.AddParameter("runStartTime", runStartTime);
-        databaseConnection.AddParameter("configuration", configuration);
-        databaseConnection.AddParameter("timeId", timeId);
+            databaseConnection.AddParameter("runStartTime", runStartTime);
+            databaseConnection.AddParameter("configuration", configuration);
+            databaseConnection.AddParameter("timeId", timeId);
         
-        var data = await databaseConnection.GetAsync($@"SELECT DISTINCT level
+            var data = await databaseConnection.GetAsync($@"SELECT DISTINCT level
 FROM {WiserTableNames.WtsLogs}
 WHERE added_on >= ?runStartTime
 AND configuration = ?configuration
 AND time_id = ?timeId");
 
-        foreach (DataRow row in data.Rows)
-        {
-            states.Add(row.Field<string>("level"));
+            foreach (DataRow row in data.Rows)
+            {
+                states.Add(row.Field<string>("level"));
+            }
         }
-
+        catch (Exception e)
+        {
+            await logService.LogError(logger, LogScopes.RunBody, logSettings, $"{configuration} failed getting log states with exception {e}", configuration, timeId);
+        }
         return states;
     }
 
     /// <inheritdoc />
-    public async Task<bool> IsServicePaused(string configuration, int timeId)
+    public async Task<bool?> IsServicePaused(string configuration, int timeId)
     {
-        using var scope = serviceProvider.CreateScope();
-        await using var databaseConnection = scope.ServiceProvider.GetRequiredService<IDatabaseConnection>();
+        try
+        {
+            using var scope = serviceProvider.CreateScope();
+            await using var databaseConnection = scope.ServiceProvider.GetRequiredService<IDatabaseConnection>();
 
-        databaseConnection.AddParameter("configuration", configuration);
-        databaseConnection.AddParameter("timeId", timeId);
+            databaseConnection.AddParameter("configuration", configuration);
+            databaseConnection.AddParameter("timeId", timeId);
 
-        var dataTable = await databaseConnection.GetAsync($@"SELECT paused
+            var dataTable = await databaseConnection.GetAsync($@"SELECT paused
 FROM {WiserTableNames.WtsServices}
 WHERE configuration = ?configuration
 AND time_id = ?timeId");
 
-        // If no service is found for this combination treat it as paused to prevent unwanted executions.
-        if (dataTable.Rows.Count == 0)
-        {
-            return true;
-        }
+            // If no service is found for this combination treat it as paused to prevent unwanted executions.
+            if (dataTable.Rows.Count == 0)
+            {
+                return true;
+            }
 
-        return dataTable.Rows[0].Field<bool>("paused");
+            return dataTable.Rows[0].Field<bool>("paused");
+        }
+        catch (Exception e)
+        {
+            await logService.LogError(logger, LogScopes.RunBody, logSettings, $"{configuration} failed getting service paused status with exception {e}", configuration, timeId);
+            return null;
+        }
     }
     
     /// <inheritdoc />
-    public async Task<bool> IsServiceRunning(string configuration, int timeId)
+    public async Task<bool?> IsServiceRunning(string configuration, int timeId)
     {
-        using var scope = serviceProvider.CreateScope();
-        await using var databaseConnection = scope.ServiceProvider.GetRequiredService<IDatabaseConnection>();
+        try
+        {
+            using var scope = serviceProvider.CreateScope();
+            await using var databaseConnection = scope.ServiceProvider.GetRequiredService<IDatabaseConnection>();
 
-        databaseConnection.AddParameter("configuration", configuration);
-        databaseConnection.AddParameter("timeId", timeId);
+            databaseConnection.AddParameter("configuration", configuration);
+            databaseConnection.AddParameter("timeId", timeId);
 
-        var dataTable = await databaseConnection.GetAsync($@"SELECT state
+            var dataTable = await databaseConnection.GetAsync($@"SELECT state
 FROM {WiserTableNames.WtsServices}
 WHERE configuration = ?configuration
 AND time_id = ?timeId");
         
-        return dataTable.Rows[0].Field<string>("state").Equals("running", StringComparison.InvariantCultureIgnoreCase);
+            return dataTable.Rows[0].Field<string>("state").Equals("running", StringComparison.InvariantCultureIgnoreCase);
+        }
+        catch (Exception e)
+        {
+            await logService.LogError(logger, LogScopes.RunBody, logSettings, $"{configuration} failed getting service running status with exception {e}", configuration, timeId);
+            return null;
+        }
     }
 }

--- a/WiserTaskScheduler/WiserTaskScheduler/Modules/Wiser/Services/WiserDashboardService.cs
+++ b/WiserTaskScheduler/WiserTaskScheduler/Modules/Wiser/Services/WiserDashboardService.cs
@@ -243,6 +243,7 @@ AND time_id = ?timeId");
         catch (Exception e)
         {
             await logService.LogError(logger, LogScopes.RunBody, logSettings, $"{configuration} failed getting log states with exception {e}", configuration, timeId);
+            return null;
         }
         return states;
     }


### PR DESCRIPTION
Added try/catch blocks around wiser dashboard database calls and updated BaseWorker to handle failing calls to prevent WTS services from getting stuck.

[1206288367732036 - Configuratie crashed bij updaten service status bij fout](https://app.asana.com/0/1205090868730163/1206288367732036)