### PR TITLE
Set a time when a specific WTS needs to be updated.

### DIFF
--- a/WiserTaskScheduler/AutoUpdater/Models/WtsModel.cs
+++ b/WiserTaskScheduler/AutoUpdater/Models/WtsModel.cs
@@ -1,4 +1,8 @@
-﻿namespace AutoUpdater.Models;
+﻿using System.ComponentModel;
+using System.Xml;
+using System.Xml.Serialization;
+
+namespace AutoUpdater.Models;
 
 public class WtsModel
 {
@@ -21,4 +25,22 @@ public class WtsModel
     /// Send a email if the WTS has been updated.
     /// </summary>
     public bool SendEmailOnUpdateComplete { get; set; }
+    
+    /// <summary>
+    /// Gets or sets the time the WTS needs to be updated. If no value has been provided or the time has already been passed the WTS will be updated immediately.
+    /// </summary>
+    [XmlIgnore]
+    public TimeSpan UpdateTime { get; set; }
+
+    /// <summary>
+    /// Gets or sets <see cref="UpdateTime"/> from a XML file.
+    /// </summary>
+    [Browsable(false)]
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    [XmlElement("UpdateTime")]
+    public string UpdateTimeString
+    {
+        get => XmlConvert.ToString(UpdateTime);
+        set => UpdateTime = String.IsNullOrWhiteSpace(value) ? TimeSpan.Zero : value.StartsWith("P") ? XmlConvert.ToTimeSpan(value) : TimeSpan.Parse(value);
+    }
 }

--- a/WiserTaskScheduler/AutoUpdater/Services/UpdateService.cs
+++ b/WiserTaskScheduler/AutoUpdater/Services/UpdateService.cs
@@ -104,14 +104,7 @@ public class UpdateService : IUpdateService
     /// <param name="versionList">All the versions of the WTS to be checked against.</param>
     private void UpdateWts(WtsModel wts, List<VersionModel> versionList)
     {
-        // If the update time is in the future wait until the update time.
-        if (wts.UpdateTime > DateTime.Now.TimeOfDay)
-        {
-            logger.LogInformation($"WTS '{wts.ServiceName}' will be updated at {wts.UpdateTime}.");
-            Thread.Sleep(wts.UpdateTime - DateTime.Now.TimeOfDay);
-        }
-        
-        logger.LogInformation($"Updating WTS '{wts.ServiceName}'.");
+        logger.LogInformation($"Checking updates for WTS '{wts.ServiceName}'.");
         
         var versionInfo = FileVersionInfo.GetVersionInfo(Path.Combine(wts.PathToFolder, WtsExeFile));
         var version = new Version(versionInfo.FileVersion);
@@ -127,6 +120,15 @@ public class UpdateService : IUpdateService
                 EmailAdministrator(wts.ContactEmail, "WTS Auto Updater - Manual action required", $"Could not update WTS '{wts.ServiceName}' to version {versionList[0].Version} due to breaking changes since the current version of the WTS ({version}).<br/>Please check the release logs and resolve the breaking changes before manually updating the WTS.", wts.ServiceName);
                 return;
             case UpdateStates.Update:
+                // If the update time is in the future wait until the update time.
+                if (wts.UpdateTime > DateTime.Now.TimeOfDay)
+                {
+                    logger.LogInformation($"WTS '{wts.ServiceName}' will be updated at {wts.UpdateTime}.");
+                    Thread.Sleep(wts.UpdateTime - DateTime.Now.TimeOfDay);
+                }
+        
+                logger.LogInformation($"Updating WTS '{wts.ServiceName}'.");
+                
                 PerformUpdate(wts, version, versionList[0].Version);
                 return;
             default:

--- a/WiserTaskScheduler/AutoUpdater/Services/UpdateService.cs
+++ b/WiserTaskScheduler/AutoUpdater/Services/UpdateService.cs
@@ -104,6 +104,13 @@ public class UpdateService : IUpdateService
     /// <param name="versionList">All the versions of the WTS to be checked against.</param>
     private void UpdateWts(WtsModel wts, List<VersionModel> versionList)
     {
+        // If the update time is in the future wait until the update time.
+        if (wts.UpdateTime > DateTime.Now.TimeOfDay)
+        {
+            logger.LogInformation($"WTS '{wts.ServiceName}' will be updated at {wts.UpdateTime}.");
+            Thread.Sleep(wts.UpdateTime - DateTime.Now.TimeOfDay);
+        }
+        
         logger.LogInformation($"Updating WTS '{wts.ServiceName}'.");
         
         var versionInfo = FileVersionInfo.GetVersionInfo(Path.Combine(wts.PathToFolder, WtsExeFile));


### PR DESCRIPTION
The auto updater checks at midnight if there is an update and then starts processing. For some projects this might be giving problem with nightly activities. This allows people to delay the actual update till a more favorable time.

https://app.asana.com/0/1205090868730163/1206271989893115