### PR TITLE
Set document store connection string

### DIFF
--- a/WiserTaskScheduler/WiserTaskScheduler/Core/Models/ConfigurationModel.cs
+++ b/WiserTaskScheduler/WiserTaskScheduler/Core/Models/ConfigurationModel.cs
@@ -51,6 +51,11 @@ namespace WiserTaskScheduler.Core.Models
         public string ConnectionString { get; set; }
 
         /// <summary>
+        /// Gets or sets the connection string that is used for the document store.
+        /// </summary>
+        public string DocumentStoreConnectionString { get; set; }
+
+        /// <summary>
         /// Gets or sets the log settings.
         /// </summary>
         public LogSettings LogSettings { get; set; }

--- a/WiserTaskScheduler/WiserTaskScheduler/WiserTaskScheduler.csproj
+++ b/WiserTaskScheduler/WiserTaskScheduler/WiserTaskScheduler.csproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="GeeksCoreLibrary" Version="4.1.3" />
+    <PackageReference Include="GeeksCoreLibrary" Version="4.1.6" />
     <PackageReference Include="jose-jwt" Version="4.1.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.1" />
     <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="7.0.1" />


### PR DESCRIPTION
The connection string for the document store can now also be set in the configuration in addition to the normal connection string. This is required when using the document store features.

[Asana ticket](https://app.asana.com/0/1200923549887805/1203802664624132)