### PR TITLE
Option for suffix for imported files

### DIFF
--- a/WiserTaskScheduler/WiserTaskScheduler/Modules/ImportFiles/Models/ImportFileModel.cs
+++ b/WiserTaskScheduler/WiserTaskScheduler/Modules/ImportFiles/Models/ImportFileModel.cs
@@ -27,7 +27,14 @@ namespace WiserTaskScheduler.Modules.ImportFiles.Models
         /// Get or sets the folder to move the file to after it has been processed. If empty, the file will not be moved.
         /// </summary>
         public string ProcessedFolder { get; set; }
-        
+
+        /// <summary>
+        /// Gets or sets whether a suffix should be added to the file name when moving it to the processed folder.
+        /// The suffix will be the current date and time in the format <c>YYYYMMDDHHMMSS</c>.
+        /// This only applies if <see cref="ProcessedFolder"/> is set.
+        /// </summary>
+        public bool AddSuffixToFileNameAfterProcessing { get; set; }
+
         /// <summary>
         /// Gets or sets the separator to split a line on.
         /// The value "\t" can be used for tab-separated files.

--- a/WiserTaskScheduler/WiserTaskScheduler/Modules/ImportFiles/Services/ImportFilesService.cs
+++ b/WiserTaskScheduler/WiserTaskScheduler/Modules/ImportFiles/Services/ImportFilesService.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using System.Xml;
@@ -177,7 +178,15 @@ namespace WiserTaskScheduler.Modules.ImportFiles.Services
                 }
 
                 // Move file if successfully imported.
-                File.Move(filePath, Path.Combine(importFile.ProcessedFolder, Path.GetFileName(filePath)));
+                var destinationFileName = new StringBuilder(Path.GetFileNameWithoutExtension(filePath));
+                if (importFile.AddSuffixToFileNameAfterProcessing)
+                {
+                    destinationFileName.Append($"_{DateTime.Now:yyyyMMddHHmmss}");
+                }
+
+                destinationFileName.Append(Path.GetExtension(filePath));
+
+                File.Move(filePath, Path.Combine(importFile.ProcessedFolder, destinationFileName.ToString()));
                 return importResult;
             }
             catch (Exception e)


### PR DESCRIPTION
Added option called `AddSuffixToFileNameAfterProcessing` that will add a suffix to files that are moved to the processed folder. If `ProcessedFolder` is not set, the suffix is not added and nothing happens. The suffix is the date and time in this format: `YYYYMMDDHHMMSS`.

There is no Asana ticket for this PR.