### PR TITLE
Obfuscate authentication headers for API calls

### DIFF
--- a/WiserTaskScheduler/WiserTaskScheduler/Core/Interfaces/ILogService.cs
+++ b/WiserTaskScheduler/WiserTaskScheduler/Core/Interfaces/ILogService.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using WiserTaskScheduler.Core.Enums;
 using WiserTaskScheduler.Core.Models;
@@ -18,7 +19,8 @@ namespace WiserTaskScheduler.Core.Interfaces
         /// <param name="configurationName">The name of the configuration from which is being logged.</param>
         /// <param name="timeId">The time id in the configuration from which is being logged.</param>
         /// <param name="order">The order in the time id in the configuration which is being logged.</param>
-        Task LogDebug<T>(ILogger<T> logger, LogScopes logScope, LogSettings logSettings, string message, string configurationName, int timeId = 0, int order = 0);
+        /// <param name="extraValuesToObfuscate">A list of extra values to obfuscate while writing logs. Used to obfuscate dynamic content such as authorization headers.</param>
+        Task LogDebug<T>(ILogger<T> logger, LogScopes logScope, LogSettings logSettings, string message, string configurationName, int timeId = 0, int order = 0, List<string> extraValuesToObfuscate = null);
 
         /// <summary>
         /// Log information.
@@ -31,7 +33,8 @@ namespace WiserTaskScheduler.Core.Interfaces
         /// <param name="configurationName">The name of the configuration from which is being logged.</param>
         /// <param name="timeId">The time id in the configuration from which is being logged.</param>
         /// <param name="order">The order in the time id in the configuration which is being logged.</param>
-        Task LogInformation<T>(ILogger<T> logger, LogScopes logScope, LogSettings logSettings, string message, string configurationName, int timeId = 0, int order = 0);
+        /// <param name="extraValuesToObfuscate">A list of extra values to obfuscate while writing logs. Used to obfuscate dynamic content such as authorization headers.</param>
+        Task LogInformation<T>(ILogger<T> logger, LogScopes logScope, LogSettings logSettings, string message, string configurationName, int timeId = 0, int order = 0, List<string> extraValuesToObfuscate = null);
 
         /// <summary>
         /// Log a warning.
@@ -44,7 +47,8 @@ namespace WiserTaskScheduler.Core.Interfaces
         /// <param name="configurationName">The name of the configuration from which is being logged.</param>
         /// <param name="timeId">The time id in the configuration from which is being logged.</param>
         /// <param name="order">The order in the time id in the configuration which is being logged.</param>
-        Task LogWarning<T>(ILogger<T> logger, LogScopes logScope, LogSettings logSettings, string message, string configurationName, int timeId = 0, int order = 0);
+        /// <param name="extraValuesToObfuscate">A list of extra values to obfuscate while writing logs. Used to obfuscate dynamic content such as authorization headers.</param>
+        Task LogWarning<T>(ILogger<T> logger, LogScopes logScope, LogSettings logSettings, string message, string configurationName, int timeId = 0, int order = 0, List<string> extraValuesToObfuscate = null);
 
         /// <summary>
         /// Log an error.
@@ -57,7 +61,8 @@ namespace WiserTaskScheduler.Core.Interfaces
         /// <param name="configurationName">The name of the configuration from which is being logged.</param>
         /// <param name="timeId">The time id in the configuration from which is being logged.</param>
         /// <param name="order">The order in the time id in the configuration which is being logged.</param>
-        Task LogError<T>(ILogger<T> logger, LogScopes logScope, LogSettings logSettings, string message, string configurationName, int timeId = 0, int order = 0);
+        /// <param name="extraValuesToObfuscate">A list of extra values to obfuscate while writing logs. Used to obfuscate dynamic content such as authorization headers.</param>
+        Task LogError<T>(ILogger<T> logger, LogScopes logScope, LogSettings logSettings, string message, string configurationName, int timeId = 0, int order = 0, List<string> extraValuesToObfuscate = null);
 
         /// <summary>
         /// Log critical.
@@ -70,7 +75,8 @@ namespace WiserTaskScheduler.Core.Interfaces
         /// <param name="configurationName">The name of the configuration from which is being logged.</param>
         /// <param name="timeId">The time id in the configuration from which is being logged.</param>
         /// <param name="order">The order in the time id in the configuration which is being logged.</param>
-        Task LogCritical<T>(ILogger<T> logger, LogScopes logScope, LogSettings logSettings, string message, string configurationName, int timeId = 0, int order = 0);
+        /// <param name="extraValuesToObfuscate">A list of extra values to obfuscate while writing logs. Used to obfuscate dynamic content such as authorization headers.</param>
+        Task LogCritical<T>(ILogger<T> logger, LogScopes logScope, LogSettings logSettings, string message, string configurationName, int timeId = 0, int order = 0, List<string> extraValuesToObfuscate = null);
 
         /// <summary>
         /// Log a message.
@@ -84,6 +90,7 @@ namespace WiserTaskScheduler.Core.Interfaces
         /// <param name="configurationName">The name of the configuration from which is being logged.</param>
         /// <param name="timeId">The time id in the configuration from which is being logged.</param>
         /// <param name="order">The order in the time id in the configuration which is being logged.</param>
-        Task Log<T>(ILogger<T> logger, LogLevel logLevel, LogScopes logScope, LogSettings logSettings, string message, string configurationName, int timeId = 0, int order = 0);
+        /// <param name="extraValuesToObfuscate">A list of extra values to obfuscate while writing logs. Used to obfuscate dynamic content such as authorization headers.</param>
+        Task Log<T>(ILogger<T> logger, LogLevel logLevel, LogScopes logScope, LogSettings logSettings, string message, string configurationName, int timeId = 0, int order = 0, List<string> extraValuesToObfuscate = null);
     }
 }

--- a/WiserTaskScheduler/WiserTaskScheduler/Core/Services/LogService.cs
+++ b/WiserTaskScheduler/WiserTaskScheduler/Core/Services/LogService.cs
@@ -32,44 +32,44 @@ namespace WiserTaskScheduler.Core.Services
         }
 
         /// <inheritdoc />
-        public async Task LogDebug<T>(ILogger<T> logger, LogScopes logScope, LogSettings logSettings, string message, string configurationName, int timeId = 0, int order = 0)
+        public async Task LogDebug<T>(ILogger<T> logger, LogScopes logScope, LogSettings logSettings, string message, string configurationName, int timeId = 0, int order = 0, List<string> extraValuesToObfuscate = null)
         {
-            await Log(logger, LogLevel.Debug, logScope, logSettings, message, configurationName, timeId, order);
+            await Log(logger, LogLevel.Debug, logScope, logSettings, message, configurationName, timeId, order, extraValuesToObfuscate);
         }
 
         /// <inheritdoc />
-        public async Task LogInformation<T>(ILogger<T> logger, LogScopes logScope, LogSettings logSettings, string message, string configurationName, int timeId = 0, int order = 0)
+        public async Task LogInformation<T>(ILogger<T> logger, LogScopes logScope, LogSettings logSettings, string message, string configurationName, int timeId = 0, int order = 0, List<string> extraValuesToObfuscate = null)
         {
-            await Log(logger, LogLevel.Information, logScope, logSettings, message, configurationName, timeId, order);
+            await Log(logger, LogLevel.Information, logScope, logSettings, message, configurationName, timeId, order, extraValuesToObfuscate);
         }
 
         /// <inheritdoc />
-        public async Task LogWarning<T>(ILogger<T> logger, LogScopes logScope, LogSettings logSettings, string message, string configurationName, int timeId = 0, int order = 0)
+        public async Task LogWarning<T>(ILogger<T> logger, LogScopes logScope, LogSettings logSettings, string message, string configurationName, int timeId = 0, int order = 0, List<string> extraValuesToObfuscate = null)
         {
-            await Log(logger, LogLevel.Warning, logScope, logSettings, message, configurationName, timeId, order);
+            await Log(logger, LogLevel.Warning, logScope, logSettings, message, configurationName, timeId, order, extraValuesToObfuscate);
         }
 
         /// <inheritdoc />
-        public async Task LogError<T>(ILogger<T> logger, LogScopes logScope, LogSettings logSettings, string message, string configurationName, int timeId = 0, int order = 0)
+        public async Task LogError<T>(ILogger<T> logger, LogScopes logScope, LogSettings logSettings, string message, string configurationName, int timeId = 0, int order = 0, List<string> extraValuesToObfuscate = null)
         {
-            await Log(logger, LogLevel.Error, logScope, logSettings, message, configurationName, timeId, order);
+            await Log(logger, LogLevel.Error, logScope, logSettings, message, configurationName, timeId, order, extraValuesToObfuscate);
         }
 
         /// <inheritdoc />
-        public async Task LogCritical<T>(ILogger<T> logger, LogScopes logScope, LogSettings logSettings, string message, string configurationName, int timeId = 0, int order = 0)
+        public async Task LogCritical<T>(ILogger<T> logger, LogScopes logScope, LogSettings logSettings, string message, string configurationName, int timeId = 0, int order = 0, List<string> extraValuesToObfuscate = null)
         {
-            await Log(logger, LogLevel.Critical, logScope, logSettings, message, configurationName, timeId, order);
+            await Log(logger, LogLevel.Critical, logScope, logSettings, message, configurationName, timeId, order, extraValuesToObfuscate);
         }
 
         /// <inheritdoc />
-        public async Task Log<T>(ILogger<T> logger, LogLevel logLevel, LogScopes logScope, LogSettings logSettings, string message, string configurationName, int timeId = 0, int order = 0)
+        public async Task Log<T>(ILogger<T> logger, LogLevel logLevel, LogScopes logScope, LogSettings logSettings, string message, string configurationName, int timeId = 0, int order = 0, List<string> extraValuesToObfuscate = null)
         {
             if (logLevel < logSettings.LogMinimumLevel)
             {
                 return;
             }
 
-            message = ObfuscateText(message);
+            message = ObfuscateText(message, extraValuesToObfuscate);
 
             switch (logScope)
             {
@@ -155,9 +155,23 @@ Message:
         /// Obfuscate the text based on the credentials in the settings.
         /// </summary>
         /// <param name="text">The text to obfuscate.</param>
+        /// <param name="extraValuesToObfuscate">A list of extra values to obfuscate while writing logs. Used to obfuscate dynamic content such as authorization headers.</param>
         /// <returns>Returns the given text with all credentials obfuscated.</returns>
-        private string ObfuscateText(string text)
+        private string ObfuscateText(string text, List<string> extraValuesToObfuscate)
         {
+            if (String.IsNullOrWhiteSpace(text) || (settings.Credentials == null && extraValuesToObfuscate == null))
+            {
+                return text;
+            }
+            
+            if (extraValuesToObfuscate != null)
+            {
+                foreach (var value in extraValuesToObfuscate)
+                {
+                    text = text.Replace(value, "*****");
+                }
+            }
+            
             if (settings.Credentials == null)
             {
                 return text;


### PR DESCRIPTION
Especially if OAuth tokens are used they can't be set in the credentials for obfuscation. Therefor if API calls include ehaders for "Authorization" or "X-API-Key" the values will be dynamically added for obfuscation in the logs.

https://app.asana.com/0/1205090868730163/1206032444292817