### PR TITLE
Fix WTS service always being marked success

### DIFF
--- a/WiserTaskScheduler/WiserTaskScheduler/Modules/Wiser/Services/WiserDashboardService.cs
+++ b/WiserTaskScheduler/WiserTaskScheduler/Modules/Wiser/Services/WiserDashboardService.cs
@@ -225,7 +225,7 @@ FROM {WiserTableNames.WtsServices}
             using var scope = serviceProvider.CreateScope();
             await using var databaseConnection = scope.ServiceProvider.GetRequiredService<IDatabaseConnection>();
 
-            databaseConnection.AddParameter("runStartTime", runStartTime);
+            databaseConnection.AddParameter("runStartTime", runStartTime.ToString("yyyy-MM-dd HH:mm:ss")); // Format to remove milliseconds.
             databaseConnection.AddParameter("configuration", configuration);
             databaseConnection.AddParameter("timeId", timeId);
         


### PR DESCRIPTION
If a run scheme was completed within a second, for example if it crashed at the beginning, the state would be marked as "success". This happened due to milliseconds not stored in the logs and thus not greater or equal than the start time that did include milliseconds.

https://app.asana.com/0/1205090868730163/1205230396767405