### PR TITLE
solve null error in parent update service when additionalDatabases ar…

### DIFF
--- a/WiserTaskScheduler/WiserTaskScheduler/Core/Services/ParentUpdateService.cs
+++ b/WiserTaskScheduler/WiserTaskScheduler/Core/Services/ParentUpdateService.cs
@@ -131,13 +131,16 @@ namespace WiserTaskScheduler.Core.Services
             
             targetDatabases.Add(new ParentUpdateDatabaseStrings(databaseConnection.ConnectedDatabase, listTablesQuery, parentsCleanUpQuery));
             
-            // Add additional databases.
-            foreach (var additionalDatabase in parentsUpdateServiceSettings.AdditionalDatabases)
+            if (parentsUpdateServiceSettings.AdditionalDatabases != null)
             {
-                listTablesQuery = $"SELECT DISTINCT `target_table` FROM `{additionalDatabase}`.`{WiserTableNames.WiserParentUpdates}`;";
-                parentsCleanUpQuery = $"TRUNCATE `{additionalDatabase}``{WiserTableNames.WiserParentUpdates}`;";
-                
-                targetDatabases.Add(new ParentUpdateDatabaseStrings(additionalDatabase, listTablesQuery, parentsCleanUpQuery));    
+                // Add additional databases.
+                foreach (var additionalDatabase in parentsUpdateServiceSettings.AdditionalDatabases)
+                {
+                    listTablesQuery = $"SELECT DISTINCT `target_table` FROM `{additionalDatabase}`.`{WiserTableNames.WiserParentUpdates}`;";
+                    parentsCleanUpQuery = $"TRUNCATE `{additionalDatabase}``{WiserTableNames.WiserParentUpdates}`;";
+
+                    targetDatabases.Add(new ParentUpdateDatabaseStrings(additionalDatabase, listTablesQuery, parentsCleanUpQuery));
+                }
             }
         }   
     }


### PR DESCRIPTION
solve null error in parent update service when additionalDatabases are not defined

# Describe your changes

when the additionalDatabases parameter is given is null causing a issue with the parent update service and never running it, this is now checked solving the issue

## Type of change

Please check only ONE option.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested?

Please describe how you tested your changes and how you confirmed this functionality is not a breaking change.

# Checklist before requesting a review
- [x] I have reviewed and tested my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation  if applicable
- [x] I selected `develop` as the base branch and not `main`, or the pull request is a hotfix that needs to be done directly on `main`
- [x] I double checked all my changes and they contain no temporary test code, no code that is commented out and no changes that are not part of this branch
- [ ] I added new unit tests for my changes if applicable

# Related pull requests

Add any open pull requests from other projects that are related to this pull request that should be merged along with this one. If there are none, you can simply say "none" or "N/A", or just leave this section empty.

# Link to Asana ticket
nvt
Add a link to the Asana ticket. Note that **_ONLY_** the URL should be added, not the name of the ticket!
