### PR TITLE
make sure parents update service does not trigger history changes

### DIFF
--- a/WiserTaskScheduler/WiserTaskScheduler/Core/Services/ParentUpdateService.cs
+++ b/WiserTaskScheduler/WiserTaskScheduler/Core/Services/ParentUpdateService.cs
@@ -96,7 +96,7 @@ namespace WiserTaskScheduler.Core.Services
                     {
                         var tableName = dataRow.Field<string>("target_table");
 
-                        var query = $"UPDATE {targetDatabase.DatabaseName}.{tableName} item INNER JOIN {targetDatabase.DatabaseName}.{WiserTableNames.WiserParentUpdates} `updates` ON `item`.id = `updates`.target_id AND `updates`.target_table = '{tableName}' SET `item`.changed_on = `updates`.changed_on, `item`.changed_by = `updates`.changed_by;";
+                        var query = $"SET @saveHistory := false; UPDATE {targetDatabase.DatabaseName}.{tableName} item INNER JOIN {targetDatabase.DatabaseName}.{WiserTableNames.WiserParentUpdates} `updates` ON `item`.id = `updates`.target_id AND `updates`.target_table = '{tableName}' SET `item`.changed_on = `updates`.changed_on, `item`.changed_by = `updates`.changed_by;";
 
                         try 
                         {


### PR DESCRIPTION
# Describe your changes

Please include a summary of the changes and relevant motivation and context.

## Type of change

Please check only ONE option.

- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested?

confirmed changes still build, as for the query the addition of the set should not cause trouble

# Checklist before requesting a review
- [ x] I have reviewed and tested my changes
- [ x] I have commented my code, particularly in hard-to-understand areas
- [ x] I have made corresponding changes to the documentation
- [ x] I selected `develop` as the base branch and not `main`, or the pull request is a hotfix that needs to be done directly on `main`
- [ x] I double checked all my changes and they contain no temporary test code, no code that is commented out and no changes that are not part of this branch
- [ x] I added new unit tests for my changes if applicable

# Related pull requests

none
# Link to Asana ticket

none, this is a issue me and @MarkVanDijkHG realized was a issue because of the branching history table growth problem
