### PR TITLE
add AUTO_INCREMENT reset and OPTIMIZE Table to parent update service

### DIFF
--- a/WiserTaskScheduler/WiserTaskScheduler/Core/Models/ParentsUpdate/ParentUpdateDatabaseStringsModel.cs
+++ b/WiserTaskScheduler/WiserTaskScheduler/Core/Models/ParentsUpdate/ParentUpdateDatabaseStringsModel.cs
@@ -3,7 +3,7 @@
 namespace WiserTaskScheduler.Core.Models.ParentsUpdate
 {
     [XmlType("ParentUpdateDatabaseStrings")]
-    public class ParentUpdateDatabaseStrings(string databaseName, string listQuery, string cleanupQuery)
+    public class ParentUpdateDatabaseStrings(string databaseName, string listQuery, string cleanupQuery, string optimizeQuery)
     {
         /// <summary>
         /// Gets or sets the database name.
@@ -20,5 +20,10 @@ namespace WiserTaskScheduler.Core.Models.ParentsUpdate
         /// Gets or sets cleanup query used to clear the table of updates after its done.
         /// </summary>
         public string CleanUpQuery { get; set; } = cleanupQuery;
+        
+        /// <summary>
+        /// Gets or sets optimize query used to optimize the table 
+        /// </summary>
+        public string OptimizeQuery { get; set; } = optimizeQuery;
     }
 }

--- a/WiserTaskScheduler/WiserTaskScheduler/Core/Models/ParentsUpdate/ParentsUpdateServiceSettings.cs
+++ b/WiserTaskScheduler/WiserTaskScheduler/Core/Models/ParentsUpdate/ParentsUpdateServiceSettings.cs
@@ -23,6 +23,12 @@ namespace WiserTaskScheduler.Core.Models.ParentsUpdate
         public string[] AdditionalDatabases { get; set; }
 
         /// <summary>
+        /// Gets or sets the setting for performing a optimize table command every X times
+        /// set to 0 for never performing optimize default is 100
+        /// </summary>
+        public int PerformOptimizeEveryXtimes { get; set; } = 100;
+
+        /// <summary>
         /// Gets or sets the log level for the parent service
         /// </summary>
         public LogSettings LogSettings { get; set; } = new LogSettings()


### PR DESCRIPTION
# Describe your changes

Since truncate was not a option we change it to a delete from, but it was requested we also reset the increment and optimize this pr adds these requests.

## Type of change

Please check only ONE option.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested?

ran it on wiser demo

# Checklist before requesting a review
- [x] I have reviewed and tested my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- made a an asana task to do this : https://app.asana.com/0/1204371236183532/1207323732304158/f
- [x] I selected `develop` as the base branch and not `main`, or the pull request is a hotfix that needs to be done directly on `main`
- [x] I double checked all my changes and they contain no temporary test code, no code that is commented out and no changes that are not part of this branch
- [x] I added new unit tests for my changes if applicable

# Related pull requests

none

# Link to Asana ticket

https://app.asana.com/0/1204371236183532/1207266233417805/f
