### PR TITLE
Feature/branch improve id mapping

### DIFF
--- a/WiserTaskScheduler/WiserTaskScheduler/Modules/Branches/Services/BranchQueueService.cs
+++ b/WiserTaskScheduler/WiserTaskScheduler/Modules/Branches/Services/BranchQueueService.cs
@@ -1022,7 +1022,17 @@ AND EXTRA NOT LIKE '%GENERATED'";
         /// <param name="branchDatabaseConnection">The database connection of the branch to use.</param>
         /// <param name="tableName">The name of the table to map the initial IDs for.</param>
         private async Task AddInitialIdMappingAsync(IDatabaseConnection branchDatabaseConnection, string tableName)
-        {      
+        {
+            // If the current table is of wiser_item then insert a record for the root folder to match for parent IDs.
+            if (tableName.EndsWith("wiser_item"))
+            {
+                await branchDatabaseConnection.ExecuteAsync($"""
+                    INSERT IGNORE INTO {WiserTableNames.WiserIdMappings} (table_name, our_id, production_id)
+                    SELECT '{tableName}', 0, 0
+                """);
+            }
+            
+            // Add all IDs from the production database to the branch database to indicate that they are already mapped.
             await branchDatabaseConnection.ExecuteAsync($"""
                 INSERT INTO {WiserTableNames.WiserIdMappings} (table_name, our_id, production_id)
                 SELECT '{tableName}', id, id


### PR DESCRIPTION
# Describe your changes

Initially add the ID mappings for Wiser items to indicate the item already exists in the main database. This is needed for later synchronisation to have an item in both databases before a merge to ensure the ID is the same. With these initial mappings it can be checked if the item can be synchronised to ensure a same ID.

Furthermore some fixes for the table copy rules have been added.

## Type of change

Please check only ONE option.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested?

Tested by creating a new branch and check if the ID mappings is filled correctly. For the table copy rules a table was excluded to check if it is left out correctly.

# Checklist before requesting a review
- [x] I have reviewed and tested my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I selected `develop` as the base branch and not `main`, or the pull request is a hotfix that needs to be done directly on `main`
- [x] I double checked all my changes and they contain no temporary test code, no code that is commented out and no changes that are not part of this branch
- [x] I added new unit tests for my changes if applicable

# Related pull requests

N/A

# Jira ticket ID

CON-274
