### PR TITLE
Fixed error that occurred when Wiser has no templates

### DIFF
--- a/WiserTaskScheduler/WiserTaskScheduler/Modules/Wiser/Services/WiserService.cs
+++ b/WiserTaskScheduler/WiserTaskScheduler/Modules/Wiser/Services/WiserService.cs
@@ -198,6 +198,10 @@ namespace WiserTaskScheduler.Modules.Wiser.Services
         private List<TemplateSettingsModel> FlattenTree(List<TemplateTreeViewModel> templateTrees)
         {
             var results = new List<TemplateSettingsModel>();
+            if (templateTrees == null)
+            {
+                return results;
+            }
 
             foreach (var templateTree in templateTrees)
             {


### PR DESCRIPTION
# Describe your changes

In the appsettings we can set a path/directory from where the WTS needs to load configurations from the templatemodule in Wiser. If the directory that you configured has no templates in it, the function `WiserService.FlattenTree` would crash with a `NullReferenceException`. This PR fixes that, now that function will just return an empty list instead.

## Type of change

Please check only ONE option.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested?

By executing the same scenario before and after my change and verify if that fixed the issue.

# Checklist before requesting a review
- [x] I have reviewed and tested my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I selected `develop` as the base branch and not `main`, or the pull request is a hotfix that needs to be done directly on `main`
- [x] I double checked all my changes and they contain no temporary test code, no code that is commented out and no changes that are not part of this branch
- [x] I added new unit tests for my changes if applicable

# Related pull requests

N/A

# Link to Asana ticket

No ticket, I noticed this problem while working on something else.
