### PR TITLE
Added support for JSON properties with dots, such as "@odata.nextpage"

### DIFF
--- a/WiserTaskScheduler/WiserTaskScheduler/Core/Helpers/ResultSetHelper.cs
+++ b/WiserTaskScheduler/WiserTaskScheduler/Core/Helpers/ResultSetHelper.cs
@@ -36,6 +36,7 @@ namespace WiserTaskScheduler.Core.Helpers
                 currentPart = keyParts[0];
 
                 // No next step left, return object as requested type.
+                // Or the entire key can be found in the result set (this can happen for properties that contain a dot in the name, such as "@odata.nextpage"),
                 if (keyParts.Length == 1 || usingResultSet.ContainsKey(key))
                 {
                     if (!key.EndsWith(']'))

--- a/WiserTaskScheduler/WiserTaskScheduler/Core/Helpers/ResultSetHelper.cs
+++ b/WiserTaskScheduler/WiserTaskScheduler/Core/Helpers/ResultSetHelper.cs
@@ -22,21 +22,21 @@ namespace WiserTaskScheduler.Core.Helpers
             {
                 return usingResultSet as T;
             }
-            
+
             if (usingResultSet == null)
             {
                 throw new ResultSetException($"Failed to get correct object because no result set was given. The key being processed is '{key}', already processed '{processedKey}'. If the key is correct but the value is not always present it is recommended to use a default value.");
             }
-            
+
             var currentPart = "";
-            
+
             try
             {
                 var keyParts = key.Split(".");
                 currentPart = keyParts[0];
 
                 // No next step left, return object as requested type.
-                if (keyParts.Length == 1)
+                if (keyParts.Length == 1 || usingResultSet.ContainsKey(key))
                 {
                     if (!key.EndsWith(']'))
                     {
@@ -61,7 +61,7 @@ namespace WiserTaskScheduler.Core.Helpers
                             return GetCorrectObject<T>(remainingKey, rows, valueAsJObject, $"{processedKey}.{currentPart}");
                     }
                 }
-            
+
                 var index = GetIndex(keyParts, rows);
                 var bracketIndexOf = currentPart.IndexOf('[');
                 var firstPartKey = currentPart;
@@ -89,7 +89,7 @@ namespace WiserTaskScheduler.Core.Helpers
             {
                 var fullKey = $"{processedKey}.{key}";
                 fullKey = fullKey.StartsWith('.') ? fullKey.Substring(1) : fullKey;
-                
+
                 throw new ResultSetException($"Something went wrong while processing the key in the result set. The key being processed is '{fullKey}' at part '{currentPart}'. Already processed '{processedKey}'. If the key is correct but the value is not always present it is recommended to use a default value.", e);
             }
         }
@@ -98,7 +98,7 @@ namespace WiserTaskScheduler.Core.Helpers
         {
             var indexLetter = keyParts[0][keyParts[0].Length - 2];
             var index = 0;
-            
+
             // If an index letter is used get the correct value based on letter, starting from 'i'.
             if (Char.IsLetter(indexLetter))
             {


### PR DESCRIPTION
# Describe your changes

I am working on importing data from an OData API. OData uses dots in some property names. This did not work with the WTS, because the WTS uses dots for JSON paths. So if the JSON has a property `{ "@odata.nextpage": "https://example.com" }`, I couldn't use that in my queries or anything, because the WTS would assume the JSON would look like this: `{ "@odata": { "nextpage": "https://example.com" } }`. I fixed this by checking if the entire key, including dots, exists in the JSON. If so, the value of that key will be returned. If not, the code will work as it did before.

## Type of change

Please check only ONE option.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested?

By running the WTS on my dev PC and checking with the debugger if the correct values are retrieved from the JSON.

# Checklist before requesting a review
- [x] I have reviewed and tested my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I selected `develop` as the base branch and not `main`, or the pull request is a hotfix that needs to be done directly on `main`
- [x] I double checked all my changes and they contain no temporary test code, no code that is commented out and no changes that are not part of this branch
- [x] I added new unit tests for my changes if applicable

# Related pull requests

N/A

# Link to Asana ticket

CON-258
