### PR TITLE
Add the success state to the result set for branch merges.

### DIFF
--- a/WiserTaskScheduler/WiserTaskScheduler/Modules/Branches/Services/BranchQueueService.cs
+++ b/WiserTaskScheduler/WiserTaskScheduler/Modules/Branches/Services/BranchQueueService.cs
@@ -1039,7 +1039,8 @@ AND EXTRA NOT LIKE '%GENERATED'";
             var result = new JObject
             {
                 {"SuccessfulChanges", 0},
-                {"Errors", errors}
+                {"Errors", errors},
+                {"Success", false}
             };
 
             // Make sure the queue table is up-to-date.
@@ -2619,6 +2620,7 @@ WHERE `id` = ?id";
 
             await FinishBranchActionAsync(queueId, dataRowWithSettings, branchQueue, configurationServiceName, databaseConnection, wiserItemsService, taskAlertsService, errors, stopwatch, startDate, branchQueue.MergedBranchTemplateId, MergeBranchSubject, MergeBranchTemplate);
 
+            result["Success"] = !errors.Any();
             return result;
         }
 


### PR DESCRIPTION
# Describe your changes

Add the success state to the result set when a branch needs to be merged. It will only be set to `true` when no errors have occured.

## Type of change

Please check only ONE option.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested?

Tested by merging a branch and checking if the state is set correctly when the merge was succesfully and when an error occured. Also validated if the value is correctly used for the `OnlyWithSuccessState` check on an action.

# Checklist before requesting a review
- [x] I have reviewed and tested my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I selected `develop` as the base branch and not `main`, or the pull request is a hotfix that needs to be done directly on `main`
- [x] I double checked all my changes and they contain no temporary test code, no code that is commented out and no changes that are not part of this branch
- [x] I added new unit tests for my changes if applicable

# Related pull requests

N/A

# Link to Asana ticket

https://app.asana.com/0/7257459017111/1206862111467207
