### PR TITLE
Handle if the Wiser refresh token is invalid

### DIFF
--- a/WiserTaskScheduler/WiserTaskScheduler/Modules/Wiser/Services/WiserService.cs
+++ b/WiserTaskScheduler/WiserTaskScheduler/Modules/Wiser/Services/WiserService.cs
@@ -122,7 +122,15 @@ namespace WiserTaskScheduler.Modules.Wiser.Services
                 var response = await client.SendAsync(request);
                 if (response.StatusCode != HttpStatusCode.OK)
                 {
-                    await logService.LogCritical(logger, LogScopes.RunStartAndStop, logSettings, "Failed to login to the Wiser API.", "WiserService");
+                    // If we are trying to refresh the token and it fails, we need to login with credentials again.
+                    if (!useRefreshToken)
+                    {
+                        await logService.LogCritical(logger, LogScopes.RunStartAndStop, logSettings, "Failed to login to the Wiser API.", "WiserService");
+                        return;
+                    }
+
+                    await logService.LogWarning(logger, LogScopes.StartAndStop, logSettings, "Failed to refresh the access token. Will try to login with credentials again.", "WiserService");
+                    await LoginAsync();
                     return;
                 }
 


### PR DESCRIPTION
# Describe your changes

When the refresh token for the Wiser API was invalid/expired it was unable to recover from this. Now it will execute a normal login.

## Type of change

Please check only ONE option.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested?

Tested by ensuring an invalid token is sent to the Wiser API to see if it falls back on the normal login.

# Checklist before requesting a review
- [x] I have reviewed and tested my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I selected `develop` as the base branch and not `main`, or the pull request is a hotfix that needs to be done directly on `main`
- [x] I double checked all my changes and they contain no temporary test code, no code that is commented out and no changes that are not part of this branch
- [x] I added new unit tests for my changes if applicable

# Related pull requests

N/A

# Link to Asana ticket

https://app.asana.com/0/1205090868730163/1207886429176436
