### PR TITLE
Show error from Wiser API

### DIFF
--- a/WiserTaskScheduler/WiserTaskScheduler/Modules/Wiser/Services/WiserService.cs
+++ b/WiserTaskScheduler/WiserTaskScheduler/Modules/Wiser/Services/WiserService.cs
@@ -172,14 +172,14 @@ namespace WiserTaskScheduler.Modules.Wiser.Services
 
                     var response = await client.SendAsync(request);
 
-                    if (response.StatusCode != HttpStatusCode.OK)
-                    {
-                        await logService.LogCritical(logger, LogScopes.RunStartAndStop, logSettings, "Failed to get configurations from the Wiser API.", "WiserService");
-                        return null;
-                    }
-
                     using var reader = new StreamReader(await response.Content.ReadAsStreamAsync());
                     var body = await reader.ReadToEndAsync();
+
+                    if (response.StatusCode != HttpStatusCode.OK)
+                    {
+                        await logService.LogCritical(logger, LogScopes.RunStartAndStop, logSettings, $"Failed to get configurations from the Wiser API.{Environment.NewLine}{Environment.NewLine}The Wiser API returned the following error:{Environment.NewLine}{body}", "WiserService");
+                        return null;
+                    }
 
                     // The call to wiser configuration responds with an html document when Wiser is updating
                     // We check for both html tag and doctype so this document is more free to change


### PR DESCRIPTION
# Describe your changes

When configurations fail to be retrieved from the Wiser API the error message from Wiser will be written to the logs and Slack if connected.

## Type of change

Please check only ONE option.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested?

Tested by checking if the flow goes correctly when a normal response is given and an error response.

# Checklist before requesting a review
- [x] I have reviewed and tested my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I selected `develop` as the base branch and not `main`, or the pull request is a hotfix that needs to be done directly on `main`
- [x] I double checked all my changes and they contain no temporary test code, no code that is commented out and no changes that are not part of this branch
- [x] I added new unit tests for my changes if applicable

# Related pull requests

https://github.com/happy-geeks/wiser/pull/703

# Link to Asana ticket

https://app.asana.com/0/7257459017111/1207193040742570
