### PR TITLE
Log service unavailable from calls to Wiser as information.

### DIFF
--- a/WiserTaskScheduler/WiserTaskScheduler/Modules/Wiser/Services/WiserService.cs
+++ b/WiserTaskScheduler/WiserTaskScheduler/Modules/Wiser/Services/WiserService.cs
@@ -120,6 +120,13 @@ namespace WiserTaskScheduler.Modules.Wiser.Services
             try
             {
                 var response = await client.SendAsync(request);
+                
+                if (response.StatusCode == HttpStatusCode.ServiceUnavailable)
+                {
+                    await logService.LogInformation(logger, LogScopes.RunStartAndStop, logSettings, "Failed to get configuration because Wiser is unavailable. This is likely due to an ongoing update.", "WiserService");
+                    return;
+                }
+
                 if (response.StatusCode != HttpStatusCode.OK)
                 {
                     // If we are trying to refresh the token and it fails, we need to login with credentials again.
@@ -186,7 +193,6 @@ namespace WiserTaskScheduler.Modules.Wiser.Services
                         await logService.LogCritical(logger, LogScopes.RunStartAndStop, logSettings, $"Failed to get configurations from the Wiser API.{Environment.NewLine}{Environment.NewLine}The Wiser API returned the following error:{Environment.NewLine}{body}", "WiserService");
                         return null;
                     }
-                    
 
                     var templateTrees = JsonConvert.DeserializeObject<List<TemplateTreeViewModel>>(body);
 

--- a/WiserTaskScheduler/WiserTaskScheduler/Modules/Wiser/Services/WiserService.cs
+++ b/WiserTaskScheduler/WiserTaskScheduler/Modules/Wiser/Services/WiserService.cs
@@ -171,6 +171,12 @@ namespace WiserTaskScheduler.Modules.Wiser.Services
                     request.Headers.Add("Authorization", $"Bearer {await GetAccessTokenAsync()}");
 
                     var response = await client.SendAsync(request);
+                    
+                    if (response.StatusCode == HttpStatusCode.ServiceUnavailable)
+                    {
+                        await logService.LogInformation(logger, LogScopes.RunStartAndStop, logSettings, "Failed to get configuration because Wiser is unavailable. This is likely due to an ongoing update.", "WiserService");
+                        return null;
+                    } 
 
                     using var reader = new StreamReader(await response.Content.ReadAsStreamAsync());
                     var body = await reader.ReadToEndAsync();
@@ -180,14 +186,7 @@ namespace WiserTaskScheduler.Modules.Wiser.Services
                         await logService.LogCritical(logger, LogScopes.RunStartAndStop, logSettings, $"Failed to get configurations from the Wiser API.{Environment.NewLine}{Environment.NewLine}The Wiser API returned the following error:{Environment.NewLine}{body}", "WiserService");
                         return null;
                     }
-
-                    // The call to wiser configuration responds with an html document when Wiser is updating
-                    // We check for both html tag and doctype so this document is more free to change
-                    if (body.StartsWith("<html", StringComparison.InvariantCultureIgnoreCase) || body.StartsWith("<!DOCTYPE html", StringComparison.InvariantCultureIgnoreCase))
-                    {
-                        await logService.LogInformation(logger, LogScopes.RunStartAndStop, logSettings, "Unable to get configuration due to Wiser update.", "WiserService");
-                        return null;
-                    }
+                    
 
                     var templateTrees = JsonConvert.DeserializeObject<List<TemplateTreeViewModel>>(body);
 

--- a/WiserTaskScheduler/WiserTaskScheduler/Modules/Wiser/Services/WiserService.cs
+++ b/WiserTaskScheduler/WiserTaskScheduler/Modules/Wiser/Services/WiserService.cs
@@ -123,7 +123,7 @@ namespace WiserTaskScheduler.Modules.Wiser.Services
                 
                 if (response.StatusCode == HttpStatusCode.ServiceUnavailable)
                 {
-                    await logService.LogInformation(logger, LogScopes.RunStartAndStop, logSettings, "Failed to get configuration because Wiser is unavailable. This is likely due to an ongoing update.", "WiserService");
+                    await logService.LogInformation(logger, LogScopes.RunStartAndStop, logSettings, "Failed to login because Wiser is unavailable. This is likely due to an ongoing update.", "WiserService");
                     return;
                 }
 


### PR DESCRIPTION
# Describe your changes

The earlier code incorrectly assumed that when the http code was 200 but the result was HTML that meant that wiser was updating.

This bugfix removed this check and instead checks for a 503 Service Unavailable response.

## Type of change

Please check only ONE option.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested?

Started the WTS to see if it could get the configurations from Wiser when service is available. 
I did not test the flow for when Wiser is unavailable

# Checklist before requesting a review
- [x] I have reviewed and tested my changes
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I selected `develop` as the base branch and not `main`, or the pull request is a hotfix that needs to be done directly on `main`
- [x] I double checked all my changes and they contain no temporary test code, no code that is commented out and no changes that are not part of this branch
- [ ] I added new unit tests for my changes if applicable

# Related pull requests

N/A

# Link to Asana ticket

https://app.asana.com/0/7257459017111/1207875524687461/f
