### PR TITLE
Change value for check

### DIFF
--- a/WiserTaskScheduler/WiserTaskScheduler/Core/Services/CleanupService.cs
+++ b/WiserTaskScheduler/WiserTaskScheduler/Core/Services/CleanupService.cs
@@ -163,7 +163,8 @@ namespace WiserTaskScheduler.Core.Services
         {
             databaseConnection.AddParameter("cleanupDate", DateTime.Now.AddDays(-cleanupServiceSettings.NumberOfDaysToStoreWtsServices));
 
-            var query = $"DELETE FROM {WiserTableNames.WtsServices} WHERE last_run < ?cleanupDate";
+            // Use the next_run column to determine if a service is older than the cleanup date to prevent paused and longer run schemes from being deleted.
+            var query = $"DELETE FROM {WiserTableNames.WtsServices} WHERE next_run < ?cleanupDate";
             var rowsDeleted = await databaseConnection.ExecuteAsync(query, cleanUp: true);
             
             await logService.LogInformation(logger, LogScopes.RunStartAndStop, LogSettings, $"Cleaned up {rowsDeleted} rows in '{WiserTableNames.WtsServices}'.", LogName);


### PR DESCRIPTION
# Describe your changes

When a configuration is paused (or has a long time between 2 runs) the service would be deleted since the last run could go over the set time. The next run is always updated and is therefor a better indication if the service has been off.

## Type of change

Please check only ONE option.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested?

Tested by having a configuration on paused with a last run a couple months old and the next run being updated. This stayed active. When having the next run a couple months old the service was removed from the wts_services table.

# Checklist before requesting a review
- [x] I have reviewed and tested my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I selected `develop` as the base branch and not `main`, or the pull request is a hotfix that needs to be done directly on `main`
- [x] I double checked all my changes and they contain no temporary test code, no code that is commented out and no changes that are not part of this branch
- [ ] I added new unit tests for my changes if applicable

# Related pull requests

N/A

# Link to Asana ticket

https://app.asana.com/0/7257459017111/1208397668109851
