### PR TITLE
solve issue where merge would fail if no wiser_styled_putput needed t…

### DIFF
--- a/WiserTaskScheduler/WiserTaskScheduler/Modules/Branches/Services/BranchQueueService.cs
+++ b/WiserTaskScheduler/WiserTaskScheduler/Modules/Branches/Services/BranchQueueService.cs
@@ -2530,19 +2530,23 @@ WHERE `id` = ?id";
                 await UpdateProgressInQueue(databaseConnection, queueId, totalItemsInHistory, true);
 
                 // Check if any ids need to be updated for styledoutput entries.
-                foreach (var oldId  in idMapping[WiserTableNames.WiserStyledOutput])
+                if (idMapping.ContainsKey(WiserTableNames.WiserStyledOutput))
                 {
-                    var newId = GetMappedId(WiserTableNames.WiserStyledOutput, idMapping, oldId.Key);
-                    if (newId != oldId.Key)
+                    foreach (var oldId in idMapping[WiserTableNames.WiserStyledOutput])
                     {
-                        // An Id is different and needs to be updated inside the styledoutputs.
-                        foreach (var processingId in idMapping[WiserTableNames.WiserStyledOutput])
+                        var newId = GetMappedId(WiserTableNames.WiserStyledOutput, idMapping, oldId.Key);
+                        if (newId != oldId.Key)
                         {
-                            await ReplaceStyledOutputIdInsideStyledOutputAsync(databaseConnection, processingId.Key, oldId.Key, newId.Value);
+                            // An Id is different and needs to be updated inside the styledoutputs.
+                            foreach (var processingId in idMapping[WiserTableNames.WiserStyledOutput])
+                            {
+                                await ReplaceStyledOutputIdInsideStyledOutputAsync(databaseConnection, processingId.Key,
+                                    oldId.Key, newId.Value);
+                            }
                         }
                     }
                 }
-                
+
                 try
                 {
                     // Clear wiser_history in the selected environment, so that next time we can just sync all changes again.


### PR DESCRIPTION
# Describe your changes

the problem was that the mapping table might not contain the wiser_styledoutput table,
this is a special case unlike the other tables which juse get checked by var name instead of const name

we now check if the key is present, solving the issue


## Type of change

Please check only ONE option.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested?

locally on wiser demo

# Checklist before requesting a review
- [x] I have reviewed and tested my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I selected `develop` as the base branch and not `main`, or the pull request is a hotfix that needs to be done directly on `main`
- [x] I double checked all my changes and they contain no temporary test code, no code that is commented out and no changes that are not part of this branch
- [x] I added new unit tests for my changes if applicable

# Related pull requests
no pull requests related

# Link to Asana ticket

[Add a link to the Asana ticket. Note that **_ONLY_** the URL should be added, not the name of the ticket!
](https://app.asana.com/0/7257459017111/1208498153222578/f)