### PR TITLE
Feature/branch merge easy objects

### DIFF
--- a/WiserTaskScheduler/AutoUpdater/AutoUpdater.csproj
+++ b/WiserTaskScheduler/AutoUpdater/AutoUpdater.csproj
@@ -15,7 +15,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="GeeksCoreLibrary" Version="4.2.18" />
+        <PackageReference Include="GeeksCoreLibrary" Version="4.2.29" />
         <PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.1" />
         <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="7.0.1" />
         <PackageReference Include="Serilog.AspNetCore" Version="7.0.0" />

--- a/WiserTaskScheduler/WiserTaskScheduler/Core/Services/OAuthService.cs
+++ b/WiserTaskScheduler/WiserTaskScheduler/Core/Services/OAuthService.cs
@@ -349,10 +349,10 @@ namespace WiserTaskScheduler.Core.Services
             using var scope = serviceProvider.CreateScope();
             var objectsService = scope.ServiceProvider.GetRequiredService<IObjectsService>();
 
-            await objectsService.SetSystemObjectValueAsync($"WTS_{oAuthApi.ApiName}_AccessToken", oAuthApi.AccessToken.EncryptWithAes(gclSettings.DefaultEncryptionKey));
-            await objectsService.SetSystemObjectValueAsync($"WTS_{oAuthApi.ApiName}_TokenType", oAuthApi.TokenType);
-            await objectsService.SetSystemObjectValueAsync($"WTS_{oAuthApi.ApiName}_RefreshToken", oAuthApi.RefreshToken.EncryptWithAes(gclSettings.DefaultEncryptionKey));
-            await objectsService.SetSystemObjectValueAsync($"WTS_{oAuthApi.ApiName}_ExpireTime", oAuthApi.ExpireTime.ToString(CultureInfo.InvariantCulture));
+            await objectsService.SetSystemObjectValueAsync($"WTS_{oAuthApi.ApiName}_AccessToken", oAuthApi.AccessToken.EncryptWithAes(gclSettings.DefaultEncryptionKey), false);
+            await objectsService.SetSystemObjectValueAsync($"WTS_{oAuthApi.ApiName}_TokenType", oAuthApi.TokenType, false);
+            await objectsService.SetSystemObjectValueAsync($"WTS_{oAuthApi.ApiName}_RefreshToken", oAuthApi.RefreshToken.EncryptWithAes(gclSettings.DefaultEncryptionKey), false);
+            await objectsService.SetSystemObjectValueAsync($"WTS_{oAuthApi.ApiName}_ExpireTime", oAuthApi.ExpireTime.ToString(CultureInfo.InvariantCulture), false);
         }
     }
 }

--- a/WiserTaskScheduler/WiserTaskScheduler/Modules/Branches/Services/BranchQueueService.cs
+++ b/WiserTaskScheduler/WiserTaskScheduler/Modules/Branches/Services/BranchQueueService.cs
@@ -1746,6 +1746,7 @@ LIMIT 1";
                         var fieldTemplatesMergeSettings = settings.Settings.SingleOrDefault(s => s.Type == WiserSettingTypes.FieldTemplates);
                         var userRoleMergeSettings = settings.Settings.SingleOrDefault(s => s.Type == WiserSettingTypes.UserRole);
                         var styledOutputMergeSettings = settings.Settings.SingleOrDefault(s => s.Type == WiserSettingTypes.StyledOutput);
+                        var objectMergeSettings = settings.Settings.SingleOrDefault(s => s.Type == WiserSettingTypes.EasyObjects);
 
                         // Update the item in the production environment.
                         switch (action)
@@ -2268,6 +2269,7 @@ WHERE `{oldValue.ToMySqlSafeValue(false)}` = ?itemId";
                             case "INSERT_API_CONNECTION":
                             case "INSERT_ROLE":
                             case "CREATE_STYLED_OUTPUT":
+                            case "CREATE_EASY_OBJECT":
                             {
                                 // Check if the user requested this change to be synchronised.
                                 switch (tableName)
@@ -2317,6 +2319,10 @@ WHERE `{oldValue.ToMySqlSafeValue(false)}` = ?itemId";
                                         await UpdateProgressInQueue(databaseConnection, queueId, itemsProcessed);
                                         continue;
                                     case WiserTableNames.WiserStyledOutput when styledOutputMergeSettings is not {Create: true}:
+                                        itemsProcessed++;
+                                        await UpdateProgressInQueue(databaseConnection, queueId, itemsProcessed);
+                                        continue;
+                                    case "easy_objects" when objectMergeSettings is not {Create: true}:
                                         itemsProcessed++;
                                         await UpdateProgressInQueue(databaseConnection, queueId, itemsProcessed);
                                         continue;
@@ -2377,6 +2383,7 @@ VALUES (?newId)";
                             case "UPDATE_API_CONNECTION":
                             case "UPDATE_ROLE":
                             case "UPDATE_STYLED_OUTPUT":
+                            case "UPDATE_EASY_OBJECT":
                             {
                                 // Check if the user requested this change to be synchronised.
                                 switch (tableName)
@@ -2429,6 +2436,10 @@ VALUES (?newId)";
                                         itemsProcessed++;
                                         await UpdateProgressInQueue(databaseConnection, queueId, itemsProcessed);
                                         continue;
+                                    case "easy_objects" when objectMergeSettings is not {Update: true}:
+                                        itemsProcessed++;
+                                        await UpdateProgressInQueue(databaseConnection, queueId, itemsProcessed);
+                                        continue;
                                 }
 
                                 sqlParameters["id"] = objectId;
@@ -2456,6 +2467,7 @@ WHERE id = ?id";
                             case "DELETE_API_CONNECTION":
                             case "DELETE_ROLE":
                             case "DELETE_STYLED_OUTPUT":
+                            case "DELETE_EASY_OBJECT":
                             {
                                 // Check if the user requested this change to be synchronised.
                                 switch (tableName)
@@ -2505,6 +2517,10 @@ WHERE id = ?id";
                                         await UpdateProgressInQueue(databaseConnection, queueId, itemsProcessed);
                                         continue;
                                     case WiserTableNames.WiserStyledOutput when styledOutputMergeSettings is not {Delete: true}:
+                                        itemsProcessed++;
+                                        await UpdateProgressInQueue(databaseConnection, queueId, itemsProcessed);
+                                        continue;
+                                    case "easy_objects" when objectMergeSettings is not {Delete: true}:
                                         itemsProcessed++;
                                         await UpdateProgressInQueue(databaseConnection, queueId, itemsProcessed);
                                         continue;

--- a/WiserTaskScheduler/WiserTaskScheduler/WiserTaskScheduler.csproj
+++ b/WiserTaskScheduler/WiserTaskScheduler/WiserTaskScheduler.csproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="GeeksCoreLibrary" Version="4.2.18" />
+    <PackageReference Include="GeeksCoreLibrary" Version="4.2.29" />
     <PackageReference Include="jose-jwt" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.1" />
     <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="7.0.1" />


### PR DESCRIPTION
# Describe your changes

Add system objects in the `easy_objects` table to be processed when merging a branch and excluding the objects for the Wiser API OAuth information from being stored in the history.

## Type of change

Please check only ONE option.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested?

Tested by creating a new object, modifying one and deleting an existing object on a branch, merge it using the WTS, and checked it in the main database. All 3 actions were performed correctly.

Validated if the objects for the Wiser API OAuth were not saved to the history, and thus ignored when merging.

# Checklist before requesting a review
- [x] I have reviewed and tested my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I selected `develop` as the base branch and not `main`, or the pull request is a hotfix that needs to be done directly on `main`
- [x] I double checked all my changes and they contain no temporary test code, no code that is commented out and no changes that are not part of this branch
- [ ] I added new unit tests for my changes if applicable

# Related pull requests

N/A

# Jira ticket ID

356
