### PR TITLE
Fix merge of file deletions

### DIFF
--- a/WiserTaskScheduler/WiserTaskScheduler/Modules/Branches/Services/BranchQueueService.cs
+++ b/WiserTaskScheduler/WiserTaskScheduler/Modules/Branches/Services/BranchQueueService.cs
@@ -2251,13 +2251,13 @@ WHERE id = ?fileId";
                                     continue;
                                 }
 
-                                sqlParameters["itemId"] = newValue;
+                                sqlParameters["fileId"] = fileId;
 
                                 await using var productionCommand = productionConnection.CreateCommand();
                                 AddParametersToCommand(sqlParameters, productionCommand);
                                 productionCommand.CommandText = $@"{queryPrefix}
 DELETE FROM `{tableName}`
-WHERE `{oldValue.ToMySqlSafeValue(false)}` = ?itemId";
+WHERE id = ?fileId";
                                 await productionCommand.ExecuteNonQueryAsync();
 
                                 break;


### PR DESCRIPTION
# Describe your changes

When a file was deleted from and item all files connected to that item would be removed on production during the merge.

Now it only deletes the specific ID in the database of the removed file. The ID used is passed through the mapping already at this point.

## Type of change

Please check only ONE option.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested?

Tested it by uploading an image and deleting the old one. Other scenario's tested were deleting the last image. Having multiple images at once and delete only one. Delete two out of three images. Deleted an image that had another ID on production than on the branch.

# Checklist before requesting a review
- [x] I have reviewed and tested my changes
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I selected `develop` as the base branch and not `main`, or the pull request is a hotfix that needs to be done directly on `main`
- [x] I double checked all my changes and they contain no temporary test code, no code that is commented out and no changes that are not part of this branch
- [ ] I added new unit tests for my changes if applicable

# Related pull requests

N/A

# Jira ticket ID

CON-977
