### PR TITLE
Fix problem that detail history was not cleaned

### DIFF
--- a/WiserTaskScheduler/WiserTaskScheduler/Modules/Branches/Services/BranchQueueService.cs
+++ b/WiserTaskScheduler/WiserTaskScheduler/Modules/Branches/Services/BranchQueueService.cs
@@ -1346,7 +1346,10 @@ public class BranchQueueService(ILogService logService, ILogger<BranchQueueServi
                     }
                 }
 
-                var objectCreatedInBranch = objectsCreatedInBranch.FirstOrDefault(i => i.ObjectId == idForComparison && String.Equals(i.TableName, tableName, StringComparison.OrdinalIgnoreCase));
+                // Treat details as items during the check for deleted items.
+                var tableNameForDeletedItemCheck = tableName.Replace(WiserTableNames.WiserItemDetail, WiserTableNames.WiserItem);
+
+                var objectCreatedInBranch = objectsCreatedInBranch.FirstOrDefault(i => i.ObjectId == idForComparison && String.Equals(i.TableName, tableNameForDeletedItemCheck, StringComparison.OrdinalIgnoreCase));
                 if (objectCreatedInBranch is {AlsoDeleted: true, AlsoUndeleted: false})
                 {
                     // This item was created and then deleted in the branch, so we don't need to do anything.


### PR DESCRIPTION
# Describe your changes

When an item was created and deleted before a merge the history entries are being cleaned. The details were left behind because they themselves are not created and deleted but only updated for the item. The check now treats details as the item.

## Type of change

Please check only ONE option.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested?

Tested by creating an item, setting details, deleting the item and merge the branch.

# Checklist before requesting a review
- [x] I have reviewed and tested my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I selected `develop` as the base branch and not `main`, or the pull request is a hotfix that needs to be done directly on `main`
- [x] I double checked all my changes and they contain no temporary test code, no code that is commented out and no changes that are not part of this branch
- [x] I added new unit tests for my changes if applicable

# Related pull requests

N/A

# Link to Asana ticket

https://app.asana.com/0/1205090868730163/1208660620737639
