### PR TITLE
Update usages of machineName with wts settings name for better server identification

### DIFF
--- a/WiserTaskScheduler/WiserTaskScheduler/Core/Models/WtsSettings.cs
+++ b/WiserTaskScheduler/WiserTaskScheduler/Core/Models/WtsSettings.cs
@@ -20,7 +20,7 @@ public class WtsSettings
     /// </summary>
     public string Name
     {
-        get => String.IsNullOrWhiteSpace(name) ? $"Wiser Task Scheduler ({Environment.MachineName})" : name;
+        get => String.IsNullOrWhiteSpace(name) ? $"({Environment.MachineName})" : name;
         init => name = value;
     }
 

--- a/WiserTaskScheduler/WiserTaskScheduler/Core/Services/AutoProjectDeployService.cs
+++ b/WiserTaskScheduler/WiserTaskScheduler/Core/Services/AutoProjectDeployService.cs
@@ -45,7 +45,7 @@ public class AutoProjectDeployService(
 {
     private readonly WtsSettings wtsSettings = wtsSettings.Value;
     private readonly GclSettings gclSettings = gclSettings.Value;
-    private readonly string logName = $"AutoProjectDeploy ({Environment.MachineName})";
+    private readonly string logName = $"AutoProjectDeploy ({wtsSettings.Value.Name})";
 
     private const string BranchSettingsEntityType = "branch_settings";
     private const string DefaultBranchSettingsId = "default_branch_settings";

--- a/WiserTaskScheduler/WiserTaskScheduler/Core/Services/AutoProjectDeployService.cs
+++ b/WiserTaskScheduler/WiserTaskScheduler/Core/Services/AutoProjectDeployService.cs
@@ -45,7 +45,7 @@ public class AutoProjectDeployService(
 {
     private readonly WtsSettings wtsSettings = wtsSettings.Value;
     private readonly GclSettings gclSettings = gclSettings.Value;
-    private readonly string logName = $"AutoProjectDeploy ({wtsSettings.Value.Name})";
+    private readonly string logName = $"AutoProjectDeploy ({Environment.MachineName} - {wtsSettings.Value.Name})";
 
     private const string BranchSettingsEntityType = "branch_settings";
     private const string DefaultBranchSettingsId = "default_branch_settings";

--- a/WiserTaskScheduler/WiserTaskScheduler/Core/Services/CleanupService.cs
+++ b/WiserTaskScheduler/WiserTaskScheduler/Core/Services/CleanupService.cs
@@ -21,7 +21,7 @@ namespace WiserTaskScheduler.Core.Services;
 /// </summary>
 public class CleanupService(IOptions<WtsSettings> wtsSettings, IServiceProvider serviceProvider, ILogService logService, ILogger<CleanupService> logger) : ICleanupService, ISingletonService
 {
-    private readonly string logName = $"CleanupService ({wtsSettings.Value.Name})";
+    private readonly string logName = $"CleanupService ({Environment.MachineName} - {wtsSettings.Value.Name})";
 
     private readonly CleanupServiceSettings cleanupServiceSettings = wtsSettings.Value.CleanupService;
 

--- a/WiserTaskScheduler/WiserTaskScheduler/Core/Services/CleanupService.cs
+++ b/WiserTaskScheduler/WiserTaskScheduler/Core/Services/CleanupService.cs
@@ -21,7 +21,7 @@ namespace WiserTaskScheduler.Core.Services;
 /// </summary>
 public class CleanupService(IOptions<WtsSettings> wtsSettings, IServiceProvider serviceProvider, ILogService logService, ILogger<CleanupService> logger) : ICleanupService, ISingletonService
 {
-    private readonly string logName = $"CleanupService ({Environment.MachineName})";
+    private readonly string logName = $"CleanupService ({wtsSettings.Value.Name})";
 
     private readonly CleanupServiceSettings cleanupServiceSettings = wtsSettings.Value.CleanupService;
 

--- a/WiserTaskScheduler/WiserTaskScheduler/Core/Services/ConfigurationsService.cs
+++ b/WiserTaskScheduler/WiserTaskScheduler/Core/Services/ConfigurationsService.cs
@@ -213,7 +213,7 @@ public class ConfigurationsService(
         catch (Exception exception)
         {
             await logService.LogCritical(logger, LogScopes.StartAndStop, LogSettings, $"Aborted {configurationServiceName} due to exception in time ID '{timeId}' and order '{currentOrder}', will try again next time. Exception {exception}", configurationServiceName, timeId, currentOrder);
-            await errorNotificationService.NotifyOfErrorByEmailAsync(serviceFailedNotificationEmails, $"Service '{configurationServiceName}' with time ID '{timeId}' of Wiser Task Scheduler '{wtsSettings.Name}' failed.", $"Wiser Task Scheduler '{wtsSettings.Name}' failed during the executing of service '{configurationServiceName}' with time ID '{timeId}' and has therefore been aborted. Please check the logs for more details. A new attempt will be made during the next run.", LogSettings, LogScopes.RunStartAndStop, configurationServiceName);
+            await errorNotificationService.NotifyOfErrorByEmailAsync(serviceFailedNotificationEmails, $"Service '{configurationServiceName}' with time ID '{timeId}' of Wiser Task Scheduler '{wtsSettings.Name}' failed.", $"Wiser Task Scheduler '{Environment.MachineName} - {wtsSettings.Name}' failed during the executing of service '{configurationServiceName}' with time ID '{timeId}' and has therefore been aborted. Please check the logs for more details. A new attempt will be made during the next run.", LogSettings, LogScopes.RunStartAndStop, configurationServiceName);
         }
     }
 

--- a/WiserTaskScheduler/WiserTaskScheduler/Core/Services/ConfigurationsService.cs
+++ b/WiserTaskScheduler/WiserTaskScheduler/Core/Services/ConfigurationsService.cs
@@ -213,7 +213,7 @@ public class ConfigurationsService(
         catch (Exception exception)
         {
             await logService.LogCritical(logger, LogScopes.StartAndStop, LogSettings, $"Aborted {configurationServiceName} due to exception in time ID '{timeId}' and order '{currentOrder}', will try again next time. Exception {exception}", configurationServiceName, timeId, currentOrder);
-            await errorNotificationService.NotifyOfErrorByEmailAsync(serviceFailedNotificationEmails, $"Service '{configurationServiceName}' with time ID '{timeId}' of '{wtsSettings.Name}' failed.", $"Wiser Task Scheduler '{wtsSettings.Name}' failed during the executing of service '{configurationServiceName}' with time ID '{timeId}' and has therefore been aborted. Please check the logs for more details. A new attempt will be made during the next run.", LogSettings, LogScopes.RunStartAndStop, configurationServiceName);
+            await errorNotificationService.NotifyOfErrorByEmailAsync(serviceFailedNotificationEmails, $"Service '{configurationServiceName}' with time ID '{timeId}' of Wiser Task Scheduler '{wtsSettings.Name}' failed.", $"Wiser Task Scheduler '{wtsSettings.Name}' failed during the executing of service '{configurationServiceName}' with time ID '{timeId}' and has therefore been aborted. Please check the logs for more details. A new attempt will be made during the next run.", LogSettings, LogScopes.RunStartAndStop, configurationServiceName);
         }
     }
 

--- a/WiserTaskScheduler/WiserTaskScheduler/Core/Services/LogService.cs
+++ b/WiserTaskScheduler/WiserTaskScheduler/Core/Services/LogService.cs
@@ -126,7 +126,7 @@ public class LogService(IServiceProvider serviceProvider, ISlackChatService slac
                         var linebreakIndex = message.IndexOf(Environment.NewLine, StringComparison.InvariantCulture);
                         var title = linebreakIndex >= 0 ? message[..linebreakIndex] : message;
                         var slackMessage = $"""
-                                            Server: {Environment.MachineName}
+                                            Server: {settings.Name}
                                             Log level: {logLevel}
                                             Configuration: '{configurationName}'
                                             Time ID: '{timeId}'

--- a/WiserTaskScheduler/WiserTaskScheduler/Core/Services/LogService.cs
+++ b/WiserTaskScheduler/WiserTaskScheduler/Core/Services/LogService.cs
@@ -126,7 +126,7 @@ public class LogService(IServiceProvider serviceProvider, ISlackChatService slac
                         var linebreakIndex = message.IndexOf(Environment.NewLine, StringComparison.InvariantCulture);
                         var title = linebreakIndex >= 0 ? message[..linebreakIndex] : message;
                         var slackMessage = $"""
-                                            Server: {settings.Name}
+                                            Server: {Environment.MachineName} - {settings.Name}
                                             Log level: {logLevel}
                                             Configuration: '{configurationName}'
                                             Time ID: '{timeId}'

--- a/WiserTaskScheduler/WiserTaskScheduler/Core/Services/MainService.cs
+++ b/WiserTaskScheduler/WiserTaskScheduler/Core/Services/MainService.cs
@@ -39,7 +39,7 @@ public class MainService(
     IErrorNotificationService errorNotificationService)
     : IMainService, ISingletonService
 {
-    private readonly string logName = $"MainService ({Environment.MachineName})";
+    private readonly string logName = $"MainService ({wtsSettings.Value.Name})";
 
     private readonly WtsSettings wtsSettings = wtsSettings.Value;
     private readonly GclSettings gclSettings = gclSettings.Value;
@@ -133,7 +133,7 @@ public class MainService(
         catch (InvalidOperationException e)
         {
             await logService.LogCritical(logger, LogScopes.StartAndStop, LogSettings, $"Could not parse OAuth configuration due to exception {e}", "OAuth");
-            await errorNotificationService.NotifyOfErrorByEmailAsync(wtsSettings.ServiceFailedNotificationEmails, $"OAuth configuration of '{wtsSettings.Name}' could not be parsed.", $"Wiser Task Scheduler '{wtsSettings.Name}' could not parse OAuth configuration. Please check the logs for more details.", LogSettings, LogScopes.StartAndStop, "OAuth");
+            await errorNotificationService.NotifyOfErrorByEmailAsync(wtsSettings.ServiceFailedNotificationEmails, $"OAuth configuration of Wiser Task Scheduler '{wtsSettings.Name}' could not be parsed.", $"Wiser Task Scheduler '{wtsSettings.Name}' could not parse OAuth configuration. Please check the logs for more details.", LogSettings, LogScopes.StartAndStop, "OAuth");
         }
 
         if (configuration != null)
@@ -266,7 +266,7 @@ public class MainService(
                 catch (InvalidOperationException e)
                 {
                     await logService.LogCritical(logger, LogScopes.StartAndStop, LogSettings, $"Could not parse configuration {wiserConfiguration.Name} due to exception {e}", wiserConfiguration.Name);
-                    await errorNotificationService.NotifyOfErrorByEmailAsync(wtsSettings.ServiceFailedNotificationEmails, $"Configuration '{wiserConfiguration.Name}' of '{wtsSettings.Name}' could not be parsed.", $"Wiser Task Scheduler '{wtsSettings.Name}' could not parse configuration '{wiserConfiguration.Name}'. Please check the logs for more details.", LogSettings, LogScopes.StartAndStop, wiserConfiguration.Name);
+                    await errorNotificationService.NotifyOfErrorByEmailAsync(wtsSettings.ServiceFailedNotificationEmails, $"Configuration '{wiserConfiguration.Name}' of Wiser Task Scheduler '{wtsSettings.Name}' could not be parsed.", $"Wiser Task Scheduler '{wtsSettings.Name}' could not parse configuration '{wiserConfiguration.Name}'. Please check the logs for more details.", LogSettings, LogScopes.StartAndStop, wiserConfiguration.Name);
                 }
 
                 if (configuration != null)
@@ -400,7 +400,7 @@ public class MainService(
             await logService.LogCritical(logger, LogScopes.StartAndStop, configuration.LogSettings, $"{configuration.ServiceName} with time ID '{runScheme.TimeId}' could not be started due to exception {e}", configuration.ServiceName, runScheme.TimeId);
             await wiserDashboardService.UpdateServiceAsync(configuration.ServiceName, runScheme.TimeId, state: "crashed");
 
-            await errorNotificationService.NotifyOfErrorByEmailAsync(String.IsNullOrWhiteSpace(configuration.ServiceFailedNotificationEmails) ? configuration.ServiceFailedNotificationEmails : wtsSettings.ServiceFailedNotificationEmails, $"Service '{configuration.ServiceName}' with time ID '{runScheme.TimeId}' of '{wtsSettings.Name}' could not be started.", $"Wiser Task Scheduler '{wtsSettings.Name}' could not start service '{configuration.ServiceName}' with time ID '{runScheme.TimeId}'. Please check the logs for more details.", runScheme.LogSettings, LogScopes.StartAndStop, configuration.ServiceName);
+            await errorNotificationService.NotifyOfErrorByEmailAsync(String.IsNullOrWhiteSpace(configuration.ServiceFailedNotificationEmails) ? configuration.ServiceFailedNotificationEmails : wtsSettings.ServiceFailedNotificationEmails, $"Service '{configuration.ServiceName}' with time ID '{runScheme.TimeId}' of Wiser Task Scheduler '{wtsSettings.Name}' could not be started.", $"Wiser Task Scheduler '{wtsSettings.Name}' could not start service '{configuration.ServiceName}' with time ID '{runScheme.TimeId}'. Please check the logs for more details.", runScheme.LogSettings, LogScopes.StartAndStop, configuration.ServiceName);
 
             return;
         }

--- a/WiserTaskScheduler/WiserTaskScheduler/Core/Services/MainService.cs
+++ b/WiserTaskScheduler/WiserTaskScheduler/Core/Services/MainService.cs
@@ -39,7 +39,7 @@ public class MainService(
     IErrorNotificationService errorNotificationService)
     : IMainService, ISingletonService
 {
-    private readonly string logName = $"MainService ({wtsSettings.Value.Name})";
+    private readonly string logName = $"MainService ({Environment.MachineName} - {wtsSettings.Value.Name})";
 
     private readonly WtsSettings wtsSettings = wtsSettings.Value;
     private readonly GclSettings gclSettings = gclSettings.Value;
@@ -133,7 +133,7 @@ public class MainService(
         catch (InvalidOperationException e)
         {
             await logService.LogCritical(logger, LogScopes.StartAndStop, LogSettings, $"Could not parse OAuth configuration due to exception {e}", "OAuth");
-            await errorNotificationService.NotifyOfErrorByEmailAsync(wtsSettings.ServiceFailedNotificationEmails, $"OAuth configuration of Wiser Task Scheduler '{wtsSettings.Name}' could not be parsed.", $"Wiser Task Scheduler '{wtsSettings.Name}' could not parse OAuth configuration. Please check the logs for more details.", LogSettings, LogScopes.StartAndStop, "OAuth");
+            await errorNotificationService.NotifyOfErrorByEmailAsync(wtsSettings.ServiceFailedNotificationEmails, $"OAuth configuration of Wiser Task Scheduler '{Environment.MachineName} - {wtsSettings.Name}' could not be parsed.", $"Wiser Task Scheduler '{Environment.MachineName} - {wtsSettings.Name}' could not parse OAuth configuration. Please check the logs for more details.", LogSettings, LogScopes.StartAndStop, "OAuth");
         }
 
         if (configuration != null)
@@ -266,7 +266,7 @@ public class MainService(
                 catch (InvalidOperationException e)
                 {
                     await logService.LogCritical(logger, LogScopes.StartAndStop, LogSettings, $"Could not parse configuration {wiserConfiguration.Name} due to exception {e}", wiserConfiguration.Name);
-                    await errorNotificationService.NotifyOfErrorByEmailAsync(wtsSettings.ServiceFailedNotificationEmails, $"Configuration '{wiserConfiguration.Name}' of Wiser Task Scheduler '{wtsSettings.Name}' could not be parsed.", $"Wiser Task Scheduler '{wtsSettings.Name}' could not parse configuration '{wiserConfiguration.Name}'. Please check the logs for more details.", LogSettings, LogScopes.StartAndStop, wiserConfiguration.Name);
+                    await errorNotificationService.NotifyOfErrorByEmailAsync(wtsSettings.ServiceFailedNotificationEmails, $"Configuration '{wiserConfiguration.Name}' of Wiser Task Scheduler '{Environment.MachineName} - {wtsSettings.Name}' could not be parsed.", $"Wiser Task Scheduler '{Environment.MachineName} - {wtsSettings.Name}' could not parse configuration '{wiserConfiguration.Name}'. Please check the logs for more details.", LogSettings, LogScopes.StartAndStop, wiserConfiguration.Name);
                 }
 
                 if (configuration != null)
@@ -400,7 +400,7 @@ public class MainService(
             await logService.LogCritical(logger, LogScopes.StartAndStop, configuration.LogSettings, $"{configuration.ServiceName} with time ID '{runScheme.TimeId}' could not be started due to exception {e}", configuration.ServiceName, runScheme.TimeId);
             await wiserDashboardService.UpdateServiceAsync(configuration.ServiceName, runScheme.TimeId, state: "crashed");
 
-            await errorNotificationService.NotifyOfErrorByEmailAsync(String.IsNullOrWhiteSpace(configuration.ServiceFailedNotificationEmails) ? configuration.ServiceFailedNotificationEmails : wtsSettings.ServiceFailedNotificationEmails, $"Service '{configuration.ServiceName}' with time ID '{runScheme.TimeId}' of Wiser Task Scheduler '{wtsSettings.Name}' could not be started.", $"Wiser Task Scheduler '{wtsSettings.Name}' could not start service '{configuration.ServiceName}' with time ID '{runScheme.TimeId}'. Please check the logs for more details.", runScheme.LogSettings, LogScopes.StartAndStop, configuration.ServiceName);
+            await errorNotificationService.NotifyOfErrorByEmailAsync(String.IsNullOrWhiteSpace(configuration.ServiceFailedNotificationEmails) ? configuration.ServiceFailedNotificationEmails : wtsSettings.ServiceFailedNotificationEmails, $"Service '{configuration.ServiceName}' with time ID '{runScheme.TimeId}' of Wiser Task Scheduler '{Environment.MachineName} - {wtsSettings.Name}' could not be started.", $"Wiser Task Scheduler '{Environment.MachineName} - {wtsSettings.Name}' could not start service '{configuration.ServiceName}' with time ID '{runScheme.TimeId}'. Please check the logs for more details.", runScheme.LogSettings, LogScopes.StartAndStop, configuration.ServiceName);
 
             return;
         }

--- a/WiserTaskScheduler/WiserTaskScheduler/Core/Services/ParentUpdateService.cs
+++ b/WiserTaskScheduler/WiserTaskScheduler/Core/Services/ParentUpdateService.cs
@@ -20,7 +20,7 @@ namespace WiserTaskScheduler.Core.Services;
 /// </summary>
 public class ParentUpdateService(IOptions<WtsSettings> wtsSettings, IServiceProvider serviceProvider, ILogService logService, ILogger<ParentUpdateService> logger) : IParentUpdateService, ISingletonService
 {
-    private readonly string logName = $"ParentUpdateService ({Environment.MachineName})";
+    private readonly string logName = $"ParentUpdateService ({wtsSettings.Value.Name})";
 
     private readonly ParentsUpdateServiceSettings parentsUpdateServiceSettings = wtsSettings.Value.ParentsUpdateService;
 

--- a/WiserTaskScheduler/WiserTaskScheduler/Core/Services/ParentUpdateService.cs
+++ b/WiserTaskScheduler/WiserTaskScheduler/Core/Services/ParentUpdateService.cs
@@ -20,7 +20,7 @@ namespace WiserTaskScheduler.Core.Services;
 /// </summary>
 public class ParentUpdateService(IOptions<WtsSettings> wtsSettings, IServiceProvider serviceProvider, ILogService logService, ILogger<ParentUpdateService> logger) : IParentUpdateService, ISingletonService
 {
-    private readonly string logName = $"ParentUpdateService ({wtsSettings.Value.Name})";
+    private readonly string logName = $"ParentUpdateService ({Environment.MachineName} - {wtsSettings.Value.Name})";
 
     private readonly ParentsUpdateServiceSettings parentsUpdateServiceSettings = wtsSettings.Value.ParentsUpdateService;
 

--- a/WiserTaskScheduler/WiserTaskScheduler/Core/Workers/BaseWorker.cs
+++ b/WiserTaskScheduler/WiserTaskScheduler/Core/Workers/BaseWorker.cs
@@ -61,7 +61,7 @@ public abstract class BaseWorker(IBaseWorkerDependencyAggregate baseWorkerDepend
             return;
         }
 
-        Name = $"{name} ({wtsSettings.Name})";
+        Name = $"{name} ({Environment.MachineName} - {wtsSettings.Name})";
         RunScheme = runScheme;
         RunImmediately = runImmediately;
         ConfigurationName = configurationName;
@@ -165,7 +165,7 @@ public abstract class BaseWorker(IBaseWorkerDependencyAggregate baseWorkerDepend
                         updateSucceeded = await wiserDashboardService.UpdateServiceAsync(ConfigurationName ?? Name, RunScheme.TimeId, nextRun: runSchemesService.GetDateTimeTillNextRun(RunScheme), lastRun: DateTime.Now, runTime: stopWatch.Elapsed, state: state, extraRun: false);
                         if (!updateSucceeded)
                         {
-                            await errorNotificationService.NotifyOfErrorByEmailAsync(serviceFailedNotificationEmails, $"Service '{ConfigurationName ?? Name}'{(RunScheme.TimeId > 0 ? $" with time ID '{RunScheme.TimeId}'" : "")} of Wiser Task Scheduler '{wtsSettings.Name}' status save failed.", $"Wiser Task Scheduler '{wtsSettings.Name}' failed to save the service '{ConfigurationName ?? Name}'{(RunScheme.TimeId > 0 ? $" with time ID '{RunScheme.TimeId}'" : "")} state of the last run, which is '{state}', to the database. The service will continue running and the next run will attempt a new state save. Until then, the service state in the database will be incorrect.", RunScheme.LogSettings, LogScopes.RunBody, ConfigurationName ?? Name);
+                            await errorNotificationService.NotifyOfErrorByEmailAsync(serviceFailedNotificationEmails, $"Service '{ConfigurationName ?? Name}'{(RunScheme.TimeId > 0 ? $" with time ID '{RunScheme.TimeId}'" : "")} of Wiser Task Scheduler '{Environment.MachineName} - {wtsSettings.Name}' status save failed.", $"Wiser Task Scheduler '{Environment.MachineName} - {wtsSettings.Name}' failed to save the service '{ConfigurationName ?? Name}'{(RunScheme.TimeId > 0 ? $" with time ID '{RunScheme.TimeId}'" : "")} state of the last run, which is '{state}', to the database. The service will continue running and the next run will attempt a new state save. Until then, the service state in the database will be incorrect.", RunScheme.LogSettings, LogScopes.RunBody, ConfigurationName ?? Name);
                         }
                     }
                     else
@@ -183,7 +183,7 @@ public abstract class BaseWorker(IBaseWorkerDependencyAggregate baseWorkerDepend
                         updateSucceeded = await wiserDashboardService.UpdateServiceAsync(ConfigurationName, RunScheme.TimeId, nextRun: runSchemesService.GetDateTimeTillNextRun(RunScheme), lastRun: DateTime.Now, runTime: stopWatch.Elapsed, state: state, extraRun: false);
                         if (!updateSucceeded)
                         {
-                            await errorNotificationService.NotifyOfErrorByEmailAsync(serviceFailedNotificationEmails, $"Service '{ConfigurationName ?? Name}'{(RunScheme.TimeId > 0 ? $" with time ID '{RunScheme.TimeId}'" : "")} of Wiser Task Scheduler '{wtsSettings.Name}' status save failed.", $"Wiser Task Scheduler '{wtsSettings.Name}' failed to save the service '{ConfigurationName ?? Name}'{(RunScheme.TimeId > 0 ? $" with time ID '{RunScheme.TimeId}'" : "")} state of the last run, which is '{state}', to the database a second time. Since this was a single run configuration, no more attempts will be made to correct this. The service state will now permanently be incorrect until it is manually updated.", RunScheme.LogSettings, LogScopes.RunStartAndStop, ConfigurationName ?? Name);
+                            await errorNotificationService.NotifyOfErrorByEmailAsync(serviceFailedNotificationEmails, $"Service '{ConfigurationName ?? Name}'{(RunScheme.TimeId > 0 ? $" with time ID '{RunScheme.TimeId}'" : "")} of Wiser Task Scheduler '{Environment.MachineName} - {wtsSettings.Name}' status save failed.", $"Wiser Task Scheduler '{Environment.MachineName} - {wtsSettings.Name}' failed to save the service '{ConfigurationName ?? Name}'{(RunScheme.TimeId > 0 ? $" with time ID '{RunScheme.TimeId}'" : "")} state of the last run, which is '{state}', to the database a second time. Since this was a single run configuration, no more attempts will be made to correct this. The service state will now permanently be incorrect until it is manually updated.", RunScheme.LogSettings, LogScopes.RunStartAndStop, ConfigurationName ?? Name);
                         }
                     }
 
@@ -202,7 +202,7 @@ public abstract class BaseWorker(IBaseWorkerDependencyAggregate baseWorkerDepend
         {
             await logService.LogCritical(logger, LogScopes.StartAndStop, RunScheme.LogSettings, $"{ConfigurationName ?? Name} stopped with exception {exception}", ConfigurationName ?? Name, RunScheme.TimeId);
             await wiserDashboardService.UpdateServiceAsync(ConfigurationName ?? Name, RunScheme.TimeId, state: "crashed");
-            await errorNotificationService.NotifyOfErrorByEmailAsync(serviceFailedNotificationEmails, $"Service '{ConfigurationName ?? Name}'{(RunScheme.TimeId > 0 ? $" with time ID '{RunScheme.TimeId}'" : "")} of Wiser Task Scheduler '{wtsSettings.Name}' crashed.", $"Wiser Task Scheduler '{wtsSettings.Name}' crashed while executing the service '{ConfigurationName ?? Name}'{(RunScheme.TimeId > 0 ? $" with time ID '{RunScheme.TimeId}'" : "")} and is therefore shutdown. Please check the logs for more details. A restart is required to start the service again.", RunScheme.LogSettings, LogScopes.StartAndStop, ConfigurationName ?? Name);
+            await errorNotificationService.NotifyOfErrorByEmailAsync(serviceFailedNotificationEmails, $"Service '{ConfigurationName ?? Name}'{(RunScheme.TimeId > 0 ? $" with time ID '{RunScheme.TimeId}'" : "")} of Wiser Task Scheduler '{Environment.MachineName} - {wtsSettings.Name}' crashed.", $"Wiser Task Scheduler '{Environment.MachineName} - {wtsSettings.Name}' crashed while executing the service '{ConfigurationName ?? Name}'{(RunScheme.TimeId > 0 ? $" with time ID '{RunScheme.TimeId}'" : "")} and is therefore shutdown. Please check the logs for more details. A restart is required to start the service again.", RunScheme.LogSettings, LogScopes.StartAndStop, ConfigurationName ?? Name);
         }
     }
 

--- a/WiserTaskScheduler/WiserTaskScheduler/Core/Workers/BaseWorker.cs
+++ b/WiserTaskScheduler/WiserTaskScheduler/Core/Workers/BaseWorker.cs
@@ -61,7 +61,7 @@ public abstract class BaseWorker(IBaseWorkerDependencyAggregate baseWorkerDepend
             return;
         }
 
-        Name = $"{name} ({Environment.MachineName})";
+        Name = $"{name} ({wtsSettings.Name})";
         RunScheme = runScheme;
         RunImmediately = runImmediately;
         ConfigurationName = configurationName;
@@ -165,7 +165,7 @@ public abstract class BaseWorker(IBaseWorkerDependencyAggregate baseWorkerDepend
                         updateSucceeded = await wiserDashboardService.UpdateServiceAsync(ConfigurationName ?? Name, RunScheme.TimeId, nextRun: runSchemesService.GetDateTimeTillNextRun(RunScheme), lastRun: DateTime.Now, runTime: stopWatch.Elapsed, state: state, extraRun: false);
                         if (!updateSucceeded)
                         {
-                            await errorNotificationService.NotifyOfErrorByEmailAsync(serviceFailedNotificationEmails, $"Service '{ConfigurationName ?? Name}'{(RunScheme.TimeId > 0 ? $" with time ID '{RunScheme.TimeId}'" : "")} of '{wtsSettings.Name}' status save failed.", $"Wiser Task Scheduler '{wtsSettings.Name}' failed to save the service '{ConfigurationName ?? Name}'{(RunScheme.TimeId > 0 ? $" with time ID '{RunScheme.TimeId}'" : "")} state of the last run, which is '{state}', to the database. The service will continue running and the next run will attempt a new state save. Until then, the service state in the database will be incorrect.", RunScheme.LogSettings, LogScopes.RunBody, ConfigurationName ?? Name);
+                            await errorNotificationService.NotifyOfErrorByEmailAsync(serviceFailedNotificationEmails, $"Service '{ConfigurationName ?? Name}'{(RunScheme.TimeId > 0 ? $" with time ID '{RunScheme.TimeId}'" : "")} of Wiser Task Scheduler '{wtsSettings.Name}' status save failed.", $"Wiser Task Scheduler '{wtsSettings.Name}' failed to save the service '{ConfigurationName ?? Name}'{(RunScheme.TimeId > 0 ? $" with time ID '{RunScheme.TimeId}'" : "")} state of the last run, which is '{state}', to the database. The service will continue running and the next run will attempt a new state save. Until then, the service state in the database will be incorrect.", RunScheme.LogSettings, LogScopes.RunBody, ConfigurationName ?? Name);
                         }
                     }
                     else
@@ -183,7 +183,7 @@ public abstract class BaseWorker(IBaseWorkerDependencyAggregate baseWorkerDepend
                         updateSucceeded = await wiserDashboardService.UpdateServiceAsync(ConfigurationName, RunScheme.TimeId, nextRun: runSchemesService.GetDateTimeTillNextRun(RunScheme), lastRun: DateTime.Now, runTime: stopWatch.Elapsed, state: state, extraRun: false);
                         if (!updateSucceeded)
                         {
-                            await errorNotificationService.NotifyOfErrorByEmailAsync(serviceFailedNotificationEmails, $"Service '{ConfigurationName ?? Name}'{(RunScheme.TimeId > 0 ? $" with time ID '{RunScheme.TimeId}'" : "")} of '{wtsSettings.Name}' status save failed.", $"Wiser Task Scheduler '{wtsSettings.Name}' failed to save the service '{ConfigurationName ?? Name}'{(RunScheme.TimeId > 0 ? $" with time ID '{RunScheme.TimeId}'" : "")} state of the last run, which is '{state}', to the database a second time. Since this was a single run configuration, no more attempts will be made to correct this. The service state will now permanently be incorrect until it is manually updated.", RunScheme.LogSettings, LogScopes.RunStartAndStop, ConfigurationName ?? Name);
+                            await errorNotificationService.NotifyOfErrorByEmailAsync(serviceFailedNotificationEmails, $"Service '{ConfigurationName ?? Name}'{(RunScheme.TimeId > 0 ? $" with time ID '{RunScheme.TimeId}'" : "")} of Wiser Task Scheduler '{wtsSettings.Name}' status save failed.", $"Wiser Task Scheduler '{wtsSettings.Name}' failed to save the service '{ConfigurationName ?? Name}'{(RunScheme.TimeId > 0 ? $" with time ID '{RunScheme.TimeId}'" : "")} state of the last run, which is '{state}', to the database a second time. Since this was a single run configuration, no more attempts will be made to correct this. The service state will now permanently be incorrect until it is manually updated.", RunScheme.LogSettings, LogScopes.RunStartAndStop, ConfigurationName ?? Name);
                         }
                     }
 
@@ -202,7 +202,7 @@ public abstract class BaseWorker(IBaseWorkerDependencyAggregate baseWorkerDepend
         {
             await logService.LogCritical(logger, LogScopes.StartAndStop, RunScheme.LogSettings, $"{ConfigurationName ?? Name} stopped with exception {exception}", ConfigurationName ?? Name, RunScheme.TimeId);
             await wiserDashboardService.UpdateServiceAsync(ConfigurationName ?? Name, RunScheme.TimeId, state: "crashed");
-            await errorNotificationService.NotifyOfErrorByEmailAsync(serviceFailedNotificationEmails, $"Service '{ConfigurationName ?? Name}'{(RunScheme.TimeId > 0 ? $" with time ID '{RunScheme.TimeId}'" : "")} of '{wtsSettings.Name}' crashed.", $"Wiser Task Scheduler '{wtsSettings.Name}' crashed while executing the service '{ConfigurationName ?? Name}'{(RunScheme.TimeId > 0 ? $" with time ID '{RunScheme.TimeId}'" : "")} and is therefore shutdown. Please check the logs for more details. A restart is required to start the service again.", RunScheme.LogSettings, LogScopes.StartAndStop, ConfigurationName ?? Name);
+            await errorNotificationService.NotifyOfErrorByEmailAsync(serviceFailedNotificationEmails, $"Service '{ConfigurationName ?? Name}'{(RunScheme.TimeId > 0 ? $" with time ID '{RunScheme.TimeId}'" : "")} of Wiser Task Scheduler '{wtsSettings.Name}' crashed.", $"Wiser Task Scheduler '{wtsSettings.Name}' crashed while executing the service '{ConfigurationName ?? Name}'{(RunScheme.TimeId > 0 ? $" with time ID '{RunScheme.TimeId}'" : "")} and is therefore shutdown. Please check the logs for more details. A restart is required to start the service again.", RunScheme.LogSettings, LogScopes.StartAndStop, ConfigurationName ?? Name);
         }
     }
 

--- a/WiserTaskScheduler/WiserTaskScheduler/Core/Workers/MainWorker.cs
+++ b/WiserTaskScheduler/WiserTaskScheduler/Core/Workers/MainWorker.cs
@@ -14,7 +14,7 @@ namespace WiserTaskScheduler.Core.Workers;
 /// </summary>
 public class MainWorker : BaseWorker
 {
-    private const string LogName = "MainService";
+    private static readonly string LogName = $"MainService ({Environment.MachineName})";
 
     private readonly IMainService mainService;
     private readonly ILogService logService;

--- a/WiserTaskScheduler/WiserTaskScheduler/Core/Workers/MainWorker.cs
+++ b/WiserTaskScheduler/WiserTaskScheduler/Core/Workers/MainWorker.cs
@@ -42,7 +42,7 @@ public class MainWorker : BaseWorker
         this.logger = logger;
         this.slackChatService = slackChatService;
 
-        wtsName = wtsSettings.Value.Name;
+        wtsName = $"{Environment.MachineName} - {wtsSettings.Value.Name}";
 
         this.mainService.LogSettings = RunScheme.LogSettings;
 

--- a/WiserTaskScheduler/WiserTaskScheduler/Core/Workers/MainWorker.cs
+++ b/WiserTaskScheduler/WiserTaskScheduler/Core/Workers/MainWorker.cs
@@ -14,12 +14,14 @@ namespace WiserTaskScheduler.Core.Workers;
 /// </summary>
 public class MainWorker : BaseWorker
 {
-    private static readonly string LogName = $"MainService ({Environment.MachineName})";
+    private const string LogName = "MainService";
 
     private readonly IMainService mainService;
     private readonly ILogService logService;
     private readonly ILogger<MainWorker> logger;
     private readonly ISlackChatService slackChatService;
+
+    private readonly string wtsName;
 
     /// <summary>
     /// Creates a new instance of <see cref="MainWorker"/>.
@@ -40,9 +42,11 @@ public class MainWorker : BaseWorker
         this.logger = logger;
         this.slackChatService = slackChatService;
 
+        wtsName = wtsSettings.Value.Name;
+
         this.mainService.LogSettings = RunScheme.LogSettings;
 
-        slackChatService.SendChannelMessageAsync($"*Wiser Task Scheduler has started ({Environment.MachineName})*");
+        slackChatService.SendChannelMessageAsync($"*Wiser Task Scheduler has started ({wtsName})*");
     }
 
     /// <inheritdoc />
@@ -55,7 +59,7 @@ public class MainWorker : BaseWorker
     public override async Task StopAsync(CancellationToken cancellationToken)
     {
         await logService.LogInformation(logger, LogScopes.StartAndStop, RunScheme.LogSettings, "Main worker needs to stop, stopping all configuration workers.", Name, RunScheme.TimeId);
-        await slackChatService.SendChannelMessageAsync($"*Wiser Task Scheduler was shut down ({Environment.MachineName})*");
+        await slackChatService.SendChannelMessageAsync($"*Wiser Task Scheduler was shut down ({wtsName})*");
         await mainService.StopAllConfigurationsAsync();
         await logService.LogInformation(logger, LogScopes.StartAndStop, RunScheme.LogSettings, "All configuration workers have stopped, stopping main worker.", Name, RunScheme.TimeId);
         await base.StopAsync(cancellationToken);


### PR DESCRIPTION
# Describe your changes

Update usages of machineName with wts name for server identification. This arose from a situation where we had multiple WTS instances writing logs to the same slack channel.

## Type of change

Please check only ONE option.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested?

Ran a local script, checked the database wts_logs to see if the wts settings name got logged instead of the machine name. Also ran some logs to slack to see if the machineName got replaced with the wts settings name.

# Checklist before requesting a review
- [x] I have reviewed and tested my changes
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I selected `develop` as the base branch and not `main`, or the pull request is a hotfix that needs to be done directly on `main`
- [x] I double checked all my changes and they contain no temporary test code, no code that is commented out and no changes that are not part of this branch
- [ ] I added new unit tests for my changes if applicable

# Related pull requests

none

# Link to Asana ticket

https://app.asana.com/0/1207852342873635/1208457193033506