### PR TITLE
Feature/document store read multiple entities

### DIFF
--- a/WiserTaskScheduler/WiserTaskScheduler/Modules/DocumentStoreRead/Models/DocumentStoreReadModel.cs
+++ b/WiserTaskScheduler/WiserTaskScheduler/Modules/DocumentStoreRead/Models/DocumentStoreReadModel.cs
@@ -20,5 +20,5 @@ public class DocumentStoreReadModel : ActionModel
     /// <summary>
     /// Gets or sets if the results of the query should be cached in the database.
     /// </summary>
-    public bool NoCache { get; set; } = false;
+    public bool NoCache { get; set; } = true;
 }

--- a/WiserTaskScheduler/WiserTaskScheduler/Modules/DocumentStoreRead/Models/DocumentStoreReadModel.cs
+++ b/WiserTaskScheduler/WiserTaskScheduler/Modules/DocumentStoreRead/Models/DocumentStoreReadModel.cs
@@ -16,4 +16,9 @@ public class DocumentStoreReadModel : ActionModel
     /// Gets or sets what published Environment the item needs to be set as
     /// </summary>
     public int? PublishedEnvironmentToSet { get; set; } = null;
+
+    /// <summary>
+    /// Gets or sets if the results of the query should be cached in the database.
+    /// </summary>
+    public bool NoCache { get; set; } = false;
 }

--- a/WiserTaskScheduler/WiserTaskScheduler/Modules/DocumentStoreRead/Services/DocumentStoreReadService.cs
+++ b/WiserTaskScheduler/WiserTaskScheduler/Modules/DocumentStoreRead/Services/DocumentStoreReadService.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Data;
+using System.Text;
 using System.Threading.Tasks;
 using GeeksCoreLibrary.Core.DependencyInjection.Interfaces;
 using GeeksCoreLibrary.Core.Enums;
@@ -55,55 +56,98 @@ public class DocumentStoreReadService(IServiceProvider serviceProvider, ILogServ
         await databaseConnection.ChangeConnectionStringsAsync(connectionString, connectionString);
         var wiserItemsService = scope.ServiceProvider.GetRequiredService<IWiserItemsService>();
 
-        var prefix = await wiserItemsService.GetTablePrefixForEntityAsync(documentStoreReadItem.EntityName);
-        var entityTypeSettings = await wiserItemsService.GetEntityTypeSettingsAsync(documentStoreReadItem.EntityName);
+        var entitiesToProcess = documentStoreReadItem.EntityName.Split(',');
+        var tableGroups = new Dictionary<string, List<string>>();
+        var settingsPerEntity = new Dictionary<string, EntitySettingsModel>();
 
-        var dataTable = await databaseConnection.GetAsync($"""
-                                                                       SELECT id
-                                                                       FROM {prefix}{WiserTableNames.WiserItem}
-                                                                       WHERE entity_type = ?entityType
-                                                                       AND json IS NOT NULL
-                                                                       AND (
-                                                           	            json_last_processed_date IS NULL
-                                                           	            OR json_last_processed_date < changed_on
-                                                                       )
-                                                           """);
-
-        foreach (DataRow row in dataTable.Rows)
+        // Get the table prefix for each entity and group them by prefix. Additionally, get the settings for each entity.
+        foreach (var entity in entitiesToProcess)
         {
-            try
+            var prefix = await wiserItemsService.GetTablePrefixForEntityAsync(entity);
+            var entityTypeSettings = await wiserItemsService.GetEntityTypeSettingsAsync(entity);
+            settingsPerEntity.Add(entity, entityTypeSettings);
+
+            if (!tableGroups.ContainsKey(prefix))
             {
-                processedItems++;
-
-                var itemId = row.Field<ulong>("id");
-                var item = await wiserItemsService.GetItemDetailsAsync(itemId, entityType: documentStoreReadItem.EntityName, skipPermissionsCheck: true);
-
-                if (item == null)
-                {
-                    await logService.LogWarning(logger, LogScopes.RunBody, documentStoreReadItem.LogSettings, $"Failed to process wiser item with ID '{itemId}' because it could not be found.", configurationServiceName, documentStoreReadItem.TimeId, documentStoreReadItem.Order);
-                    failedItems++;
-                    continue;
-                }
-
-                if (documentStoreReadItem.PublishedEnvironmentToSet != null)
-                {
-                    item.PublishedEnvironment = (Environments) documentStoreReadItem.PublishedEnvironmentToSet;
-                }
-
-                if (entityTypeSettings.StoreType == StoreType.Hybrid)
-                {
-                    // Set the json to null to mark the item as processed. Hybrid mode will then no longer load and update by JSON.
-                    item.Json = null;
-                }
-
-                item.JsonLastProcessedDate = DateTime.Now;
-                await wiserItemsService.SaveAsync(item, username: "WTS", storeTypeOverride: StoreType.Table, skipPermissionsCheck: true);
-                successfulItems++;
+                tableGroups.Add(prefix, new List<string>());
             }
-            catch (Exception e)
+
+            tableGroups[prefix].Add(entity);
+        }
+
+        // Process each group of entities.
+        foreach (var tableGroup in tableGroups)
+        {
+            var entityWherePart = new StringBuilder();
+
+            // If there is only one entity in the group, use an equals comparison. Otherwise, use an IN comparison.
+            if (tableGroup.Value.Count == 1)
             {
-                failedItems++;
-                await logService.LogWarning(logger, LogScopes.RunBody, documentStoreReadItem.LogSettings, $"Failed to process wiser item due to exception:\n{e}", configurationServiceName, documentStoreReadItem.TimeId, documentStoreReadItem.Order);
+                databaseConnection.AddParameter("entityType", tableGroup.Value[0]);
+                entityWherePart.Append("= ?entityType");
+            }
+            else
+            {
+                entityWherePart.Append("IN (");
+
+                // Dynamically add parameters for each entity in the group.
+                for (var i = 0; i < tableGroup.Value.Count; i++)
+                {
+                    databaseConnection.AddParameter($"entityType{i}", tableGroup.Value[i]);
+                    entityWherePart.Append($"{(i == 0 ? "" : ", ")}?entityType{i}");
+                }
+
+                entityWherePart.Append(')');
+            }
+
+            var dataTable = await databaseConnection.GetAsync($"""
+                                                                           SELECT {(documentStoreReadItem.NoCache ? "SQL_NO_CACHE" : "")} id
+                                                                           FROM {tableGroup.Key}{WiserTableNames.WiserItem}
+                                                                           WHERE entity_type {entityWherePart}
+                                                                           AND json IS NOT NULL
+                                                                           AND (
+                                                               	            json_last_processed_date IS NULL
+                                                               	            OR json_last_processed_date < changed_on
+                                                                           )
+                                                               """);
+
+            // Process each item in the group.
+            foreach (DataRow row in dataTable.Rows)
+            {
+                try
+                {
+                    processedItems++;
+
+                    var itemId = row.Field<ulong>("id");
+                    var item = await wiserItemsService.GetItemDetailsAsync(itemId, entityType: documentStoreReadItem.EntityName, skipPermissionsCheck: true);
+
+                    if (item == null)
+                    {
+                        await logService.LogWarning(logger, LogScopes.RunBody, documentStoreReadItem.LogSettings, $"Failed to process wiser item with ID '{itemId}' because it could not be found.", configurationServiceName, documentStoreReadItem.TimeId, documentStoreReadItem.Order);
+                        failedItems++;
+                        continue;
+                    }
+
+                    if (documentStoreReadItem.PublishedEnvironmentToSet != null)
+                    {
+                        item.PublishedEnvironment = (Environments) documentStoreReadItem.PublishedEnvironmentToSet;
+                    }
+
+                    if (settingsPerEntity[tableGroup.Key].StoreType == StoreType.Hybrid)
+                    {
+                        // Set the json to null to mark the item as processed. Hybrid mode will then no longer load and update by JSON.
+                        item.Json = null;
+                    }
+
+                    item.JsonLastProcessedDate = DateTime.Now;
+                    await wiserItemsService.SaveAsync(item, username: "WTS", storeTypeOverride: StoreType.Table, skipPermissionsCheck: true);
+                    successfulItems++;
+                }
+                catch (Exception e)
+                {
+                    failedItems++;
+                    await logService.LogWarning(logger, LogScopes.RunBody, documentStoreReadItem.LogSettings, $"Failed to process wiser item due to exception:\n{e}", configurationServiceName, documentStoreReadItem.TimeId, documentStoreReadItem.Order);
+                }
             }
         }
 


### PR DESCRIPTION
# Describe your changes

Add support for the `DocumentStoreRead` action to process multiple entities at once. This is useful to gather all information in one query instead of multiple queries.

Added flag for SELECT-statement to prevent caching of the query results.

## Type of change

Please check only ONE option.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested?

Tested by using 1 entity, 2 entities of the same `wiser_table` and 3 entities of which 1 in a different table. All situations processed correctly. Tested with and without the cache flag.

# Checklist before requesting a review
- [x] I have reviewed and tested my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I selected `develop` as the base branch and not `main`, or the pull request is a hotfix that needs to be done directly on `main`
- [x] I double checked all my changes and they contain no temporary test code, no code that is commented out and no changes that are not part of this branch
- [ ] I added new unit tests for my changes if applicable

# Related pull requests

N/A

# Jira ticket ID

CON-1363
