### PR TITLE
Feature/cleanup full history

### DIFF
--- a/WiserTaskScheduler/WiserTaskScheduler/Modules/CleanupWiserHistory/Models/CleanupWiserHistoryModel.cs
+++ b/WiserTaskScheduler/WiserTaskScheduler/Modules/CleanupWiserHistory/Models/CleanupWiserHistoryModel.cs
@@ -15,6 +15,11 @@ public class CleanupWiserHistoryModel : ActionModel
     public string EntityName { get; set; }
 
     /// <summary>
+    /// Gets or sets if all entities need to be cleaned instead of a specific one.
+    /// </summary>
+    public bool CleanupAllEntities { get; set; }
+
+    /// <summary>
     /// Gets or sets the time the history of the given entity needs to be stored.
     /// </summary>
     [XmlIgnore]

--- a/WiserTaskScheduler/WiserTaskScheduler/Modules/CleanupWiserHistory/Services/CleanupWiserHistoryService.cs
+++ b/WiserTaskScheduler/WiserTaskScheduler/Modules/CleanupWiserHistory/Services/CleanupWiserHistoryService.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Data;
+using System.Linq;
 using System.Threading.Tasks;
 using GeeksCoreLibrary.Core.DependencyInjection.Interfaces;
 using GeeksCoreLibrary.Core.Interfaces;
@@ -67,7 +69,7 @@ public class CleanupWiserHistoryService(IServiceProvider serviceProvider, ILogSe
             };
         }
 
-        await logService.LogInformation(logger, LogScopes.RunStartAndStop, cleanupWiserHistory.LogSettings, $"Starting cleanup for history of entity '{cleanupWiserHistory.EntityName}' that are older than '{cleanupWiserHistory.TimeToStore}'.", configurationServiceName, cleanupWiserHistory.TimeId, cleanupWiserHistory.Order);
+        await logService.LogInformation(logger, LogScopes.RunStartAndStop, cleanupWiserHistory.LogSettings, $"Starting cleanup for history entries{(String.IsNullOrWhiteSpace(cleanupWiserHistory.EntityName) ? "" : $" of entity '{cleanupWiserHistory.EntityName}'")} that are older than '{cleanupWiserHistory.TimeToStore}'.", configurationServiceName, cleanupWiserHistory.TimeId, cleanupWiserHistory.Order);
 
         using var scope = serviceProvider.CreateScope();
         await using var databaseConnection = scope.ServiceProvider.GetRequiredService<IDatabaseConnection>();
@@ -76,37 +78,60 @@ public class CleanupWiserHistoryService(IServiceProvider serviceProvider, ILogSe
         await databaseConnection.ChangeConnectionStringsAsync(connectionStringToUse, connectionStringToUse);
         databaseConnection.ClearParameters();
 
-        var wiserItemsService = scope.ServiceProvider.GetRequiredService<IWiserItemsService>();
-        var tablePrefix = await wiserItemsService.GetTablePrefixForEntityAsync(cleanupWiserHistory.EntityName);
-
         var cleanupDate = DateTime.Now.Subtract(cleanupWiserHistory.TimeToStore);
-        databaseConnection.AddParameter("entityName", cleanupWiserHistory.EntityName);
         databaseConnection.AddParameter("cleanupDate", cleanupDate);
-        databaseConnection.AddParameter("tableName", $"{tablePrefix}{WiserTableNames.WiserItem}");
 
-        // TODO: Check if we have a specific entity or need to clean the full history.
-        // TODO: Get IDs from history table and then delete in a separate query to optimize performance.
-        var historyRowsDeleted = 0;
+        var historyEntriesToDelete = new List<ulong>();
+
         if (!String.IsNullOrWhiteSpace(cleanupWiserHistory.EntityName))
         {
-            historyRowsDeleted = await databaseConnection.ExecuteAsync($"""
+            var wiserItemsService = scope.ServiceProvider.GetRequiredService<IWiserItemsService>();
+            var tablePrefix = await wiserItemsService.GetTablePrefixForEntityAsync(cleanupWiserHistory.EntityName);
 
-                                                                            DELETE history.*
-                                                                            FROM {tablePrefix}{WiserTableNames.WiserItem} AS item
-                                                                            JOIN {WiserTableNames.WiserHistory} AS history ON history.item_id = item.id AND history.tablename LIKE CONCAT(?tableName, '%') AND history.changed_on < ?cleanupDate
-                                                                            WHERE item.entity_type = ?entityName
-                                                                            """);
+            databaseConnection.AddParameter("entityName", cleanupWiserHistory.EntityName);
+            databaseConnection.AddParameter("tableName", $"{tablePrefix}{WiserTableNames.WiserItem}");
 
-            historyRowsDeleted += await databaseConnection.ExecuteAsync($"""
+            var dataTable = await databaseConnection.GetAsync($"""
+                                                               SELECT CAST(history.id AS UNSIGNED) AS id
+                                                               FROM {tablePrefix}{WiserTableNames.WiserItem} AS item
+                                                               JOIN {WiserTableNames.WiserHistory} AS history ON history.item_id = item.id AND history.tablename LIKE CONCAT(?tableName, '%') AND history.changed_on < ?cleanupDate
+                                                               WHERE item.entity_type = ?entityName
+                                                               """);
 
-                                                                         DELETE history.*
-                                                                         FROM {tablePrefix}{WiserTableNames.WiserItem}{WiserTableNames.ArchiveSuffix} AS item
-                                                                         JOIN {WiserTableNames.WiserHistory} AS history ON history.item_id = item.id AND history.tablename LIKE CONCAT(?tableName, '%') AND history.changed_on < ?cleanupDate
-                                                                         WHERE item.entity_type = ?entityName
-                                                                         """);
+            historyEntriesToDelete.AddRange(from DataRow row in dataTable.Rows select row.Field<ulong>("id"));
+
+            dataTable = await databaseConnection.GetAsync($"""
+                                                           SELECT CAST(history.id AS UNSIGNED) AS id
+                                                           FROM {tablePrefix}{WiserTableNames.WiserItem}{WiserTableNames.ArchiveSuffix} AS item
+                                                           JOIN {WiserTableNames.WiserHistory} AS history ON history.item_id = item.id AND history.tablename LIKE CONCAT(?tableName, '%')AND history.changed_on < ?cleanupDate
+                                                           WHERE item.entity_type = ?entityName
+                                                           """);
+
+            historyEntriesToDelete.AddRange(from DataRow row in dataTable.Rows select row.Field<ulong>("id"));
+        }
+        else if (cleanupWiserHistory.CleanupAllEntities)
+        {
+            var dataTable = await databaseConnection.GetAsync($"""
+                                                               SELECT CAST(history.id AS UNSIGNED) AS id
+                                                               FROM {WiserTableNames.WiserHistory} AS history
+                                                               WHERE history.changed_on < ?cleanupDate
+                                                               """);
+
+            historyEntriesToDelete.AddRange(from DataRow row in dataTable.Rows select row.Field<ulong>("id"));
         }
 
-        await logService.LogInformation(logger, LogScopes.RunStartAndStop, cleanupWiserHistory.LogSettings, $"'{historyRowsDeleted}' {(historyRowsDeleted == 1 ? "row has" : "rows have")} been deleted from the history of items of entity '{cleanupWiserHistory.EntityName}'.", configurationServiceName, cleanupWiserHistory.TimeId, cleanupWiserHistory.Order);
+        var historyRowsDeleted = 0;
+        if (historyEntriesToDelete.Count > 0)
+        {
+            databaseConnection.ClearParameters();
+
+            historyRowsDeleted = await databaseConnection.ExecuteAsync($"""
+                                                                      DELETE FROM {WiserTableNames.WiserHistory}
+                                                                      WHERE id IN ({String.Join(", ", historyEntriesToDelete)})
+                                                                      """);
+        }
+
+        await logService.LogInformation(logger, LogScopes.RunStartAndStop, cleanupWiserHistory.LogSettings, $"'{historyRowsDeleted}' {(historyRowsDeleted == 1 ? "row has" : "rows have")} been deleted from the history{(String.IsNullOrWhiteSpace(cleanupWiserHistory.EntityName) ? "" : $" of items of entity '{cleanupWiserHistory.EntityName}'")}.", configurationServiceName, cleanupWiserHistory.TimeId, cleanupWiserHistory.Order);
 
         if (cleanupWiserHistory.OptimizeTablesAfterCleanup && historyRowsDeleted > 0)
         {
@@ -116,7 +141,7 @@ public class CleanupWiserHistoryService(IServiceProvider serviceProvider, ILogSe
         return new JObject
         {
             {"Success", true},
-            {"EntityName", cleanupWiserHistory.EntityName},
+            {"EntityName", String.IsNullOrWhiteSpace(cleanupWiserHistory.EntityName) ? "All" : cleanupWiserHistory.EntityName},
             {"CleanupDate", cleanupDate},
             {"HistoryRowsDeleted", historyRowsDeleted}
         };

--- a/WiserTaskScheduler/WiserTaskScheduler/Modules/CleanupWiserHistory/Services/CleanupWiserHistoryService.cs
+++ b/WiserTaskScheduler/WiserTaskScheduler/Modules/CleanupWiserHistory/Services/CleanupWiserHistoryService.cs
@@ -98,7 +98,7 @@ public class CleanupWiserHistoryService(IServiceProvider serviceProvider, ILogSe
                                                                WHERE item.entity_type = ?entityName
                                                                """);
 
-            historyEntriesToDelete.AddRange(from DataRow row in dataTable.Rows select row.Field<ulong>("id"));
+            historyEntriesToDelete.AddRange(dataTable.AsEnumerable().Select(row => row.Field<ulong>("id")));
 
             dataTable = await databaseConnection.GetAsync($"""
                                                            SELECT CAST(history.id AS UNSIGNED) AS id
@@ -107,7 +107,7 @@ public class CleanupWiserHistoryService(IServiceProvider serviceProvider, ILogSe
                                                            WHERE item.entity_type = ?entityName
                                                            """);
 
-            historyEntriesToDelete.AddRange(from DataRow row in dataTable.Rows select row.Field<ulong>("id"));
+            historyEntriesToDelete.AddRange(dataTable.AsEnumerable().Select(row => row.Field<ulong>("id")));
         }
         else if (cleanupWiserHistory.CleanupAllEntities)
         {
@@ -117,7 +117,7 @@ public class CleanupWiserHistoryService(IServiceProvider serviceProvider, ILogSe
                                                                WHERE history.changed_on < ?cleanupDate
                                                                """);
 
-            historyEntriesToDelete.AddRange(from DataRow row in dataTable.Rows select row.Field<ulong>("id"));
+            historyEntriesToDelete.AddRange(dataTable.AsEnumerable().Select(row => row.Field<ulong>("id")));
         }
 
         var historyRowsDeleted = 0;


### PR DESCRIPTION
# Describe your changes

Extended the functionality for the Wiser history to allow clean up of the full history instead of only specific entities. This allows for a quick cleaning of the `wiser_history` table without needing the add all entities and keep the list updated when new entities have been added.

## Type of change

Please check only ONE option.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested?

Tested by cleaning the history of a specific entity and for the full history.

# Checklist before requesting a review
- [x] I have reviewed and tested my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I selected `develop` as the base branch and not `main`, or the pull request is a hotfix that needs to be done directly on `main`
- [x] I double checked all my changes and they contain no temporary test code, no code that is commented out and no changes that are not part of this branch
- [ ] I added new unit tests for my changes if applicable

# Related pull requests

N/A

# Jira ticket ID

CON-1422
