### PR TITLE
ensure we check for a database connection before performing parent up…

### DIFF
--- a/WiserTaskScheduler/WiserTaskScheduler/Core/Services/ParentUpdateService.cs
+++ b/WiserTaskScheduler/WiserTaskScheduler/Core/Services/ParentUpdateService.cs
@@ -80,6 +80,15 @@ public class ParentUpdateService(IOptions<WtsSettings> wtsSettings, IServiceProv
     /// <param name="targetDatabase">The database we are applying the parent updates on.</param>
     private async Task ParentsUpdateMainAsync(IDatabaseConnection databaseConnection, IDatabaseHelpersService databaseHelpersService, ParentUpdateDatabaseStrings targetDatabase)
     {
+        await databaseConnection.EnsureOpenConnectionForWritingAsync();
+
+        if (databaseConnection.ConnectedDatabaseForWriting == null)
+        {
+            // No need to log this, If we dont have a database connection just skip it for now.
+            // We run the updates once we database connection is back and adding logs here would just flood the logs.
+            return;
+        }
+
         if (await databaseHelpersService.DatabaseExistsAsync(targetDatabase.DatabaseName))
         {
             if (await databaseHelpersService.TableExistsAsync(WiserTableNames.WiserParentUpdates, targetDatabase.DatabaseName))
@@ -127,6 +136,15 @@ public class ParentUpdateService(IOptions<WtsSettings> wtsSettings, IServiceProv
     /// <param name="targetDatabase">The database we are applying the parent updates on.</param>
     private async Task ParentsUpdateOptimizeTables(IDatabaseConnection databaseConnection, IDatabaseHelpersService databaseHelpersService, ParentUpdateDatabaseStrings targetDatabase)
     {
+        await databaseConnection.EnsureOpenConnectionForWritingAsync();
+
+        if (databaseConnection.ConnectedDatabaseForWriting == null)
+        {
+            // No need to log this, If we dont have a database connection just skip it for now.
+            // We run the updates once we database connection is back and adding logs here would just flood the logs.
+            return;
+        }
+
         if (await databaseHelpersService.DatabaseExistsAsync(targetDatabase.DatabaseName))
         {
             if (await databaseHelpersService.TableExistsAsync(WiserTableNames.WiserParentUpdates, targetDatabase.DatabaseName))


### PR DESCRIPTION
…dates or optimize operations in the parentsupdatesservice

# Describe your changes

in the rare case that a WTS has a issue with the database connection the parent update service crashes.
I added 2 checks to the routines so it makes sure it does not do any operations when we do not have a connection to prevent these crashes

## Type of change

Please check only ONE option.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested?

I tested it on wiserdemo but its a difficult thing to test since we kind of always have a database connection untill stuff really goes wrong, i made sure atleast that it doesn not crash on startup ;) 

# Checklist before requesting a review
- [x] I have reviewed and tested my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I selected `develop` as the base branch and not `main`, or the pull request is a hotfix that needs to be done directly on `main`
- [x] I double checked all my changes and they contain no temporary test code, no code that is commented out and no changes that are not part of this branch
- [ ] I added new unit tests for my changes if applicable

# Related pull requests

Add any open pull requests from other projects that are related to this pull request that should be merged along with this one. If there are none, you can simply say "none" or "N/A", or just leave this section empty.

# Link to Asana ticket

IG ticket
