### PR TITLE
Revert update when exe file is not present

### DIFF
--- a/WiserTaskScheduler/AutoUpdater/Program.cs
+++ b/WiserTaskScheduler/AutoUpdater/Program.cs
@@ -22,7 +22,7 @@ var host = Host.CreateDefaultBuilder(args)
 
         var secretsBasePath = hostingContext.Configuration.GetSection("Updater").GetValue<string>("SecretsBaseDirectory");
 
-        config.AddJsonFile($"{secretsBasePath}updater-appsettings-secrets.json", false, false)
+        config.AddJsonFile(Path.Combine(secretsBasePath, "updater-appsettings-secrets.json"), false, false)
             .AddJsonFile($"appsettings.{hostingContext.HostingEnvironment.EnvironmentName}.json", true, true);
     })
     .ConfigureServices((hostContext, services) =>
@@ -45,7 +45,7 @@ var host = Host.CreateDefaultBuilder(args)
         services.AddHttpContextAccessor();
         services.AddGclServices(hostContext.Configuration, false, false, false);
 
-        // If there is a bot token provided for Slack add the service. 
+        // If there is a bot token provided for Slack add the service.
         var slackBotToken = slackSettings.GetValue<string>("BotToken");
         if (!String.IsNullOrWhiteSpace(slackBotToken))
         {


### PR DESCRIPTION
# Describe your changes

If a WTS was being updated but was offline it wouldn't notice the exe file was missing in the update. This extra check makes sure there is an exe file after the update and otherwise reverts to the backup.

## Type of change

Please check only ONE option.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested?

Tested by checking the flow if there is and isn't an executable present and when the WTS is active and not active.

# Checklist before requesting a review
- [x] I have reviewed and tested my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I selected `develop` as the base branch and not `main`, or the pull request is a hotfix that needs to be done directly on `main`
- [x] I double checked all my changes and they contain no temporary test code, no code that is commented out and no changes that are not part of this branch
- [ ] I added new unit tests for my changes if applicable

# Related pull requests

N/A

# Link to Asana ticket

https://app.asana.com/1/5038780173035/project/1205090868730163/task/1209123188104215
