### PR TITLE
Fix parent item ID not being mapped during merge

### DIFF
--- a/WiserTaskScheduler/AutoUpdater/AutoUpdater.csproj
+++ b/WiserTaskScheduler/AutoUpdater/AutoUpdater.csproj
@@ -15,7 +15,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="GeeksCoreLibrary" Version="5.3.2506.3" />
+        <PackageReference Include="GeeksCoreLibrary" Version="5.3.2507.6" />
         <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.4" />
         <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="9.0.4" />
         <PackageReference Include="Serilog.AspNetCore" Version="9.0.0"/>

--- a/WiserTaskScheduler/WiserTaskScheduler/Modules/Branches/Services/BranchQueueService.cs
+++ b/WiserTaskScheduler/WiserTaskScheduler/Modules/Branches/Services/BranchQueueService.cs
@@ -1761,6 +1761,38 @@ public class BranchQueueService(ILogService logService, ILogger<BranchQueueServi
                                 continue;
                             }
 
+                            // If the field is the parent item ID, we need to map it based on the entity type of the parent item. When no parent item ID is set, we can skip this step since 0 is the default value for parent item ID.
+                            if (actionData.Field.Equals("parent_item_id", StringComparison.OrdinalIgnoreCase) && actionData.NewValue != "0")
+                            {
+                                actionData.MessageBuilder.AppendLine($"The field '{actionData.Field}' is a special field that needs to be mapped based on the entity of the parent.");
+
+                                var originalParentItemId = UInt64.Parse(actionData.NewValue);
+                                var linkTypeSettings = allLinkTypeSettings.Single(l => l.Type == 1 && l.SourceEntityType.Equals(actionData.ItemEntityType, StringComparison.OrdinalIgnoreCase) && l.UseItemParentId);
+
+                                actionData.MessageBuilder.AppendLine($"--> To determine the entity type of the parent, to find the correct prefix, we found the link type settings (ID: '{linkTypeSettings.Id}') for the link type '{linkTypeSettings.Type}' with source entity type '{linkTypeSettings.SourceEntityType}' and destination entity type '{linkTypeSettings.DestinationEntityType}'.");
+
+                                // Retrieve the entity type settings of the parent item, if not already cached to determine the table prefix.
+                                _ = allEntityTypeSettings.TryGetValue(linkTypeSettings.DestinationEntityType, out var entitySettingsOfParent);
+                                if (entitySettingsOfParent == null)
+                                {
+                                    entitySettingsOfParent = await branchEntityTypesService.GetEntityTypeSettingsAsync(linkTypeSettings.DestinationEntityType);
+                                    if (entitySettingsOfParent != null)
+                                    {
+                                        allEntityTypeSettings.Add(linkTypeSettings.DestinationEntityType, entitySettingsOfParent);
+                                    }
+                                }
+
+                                var parentEntityTablePrefix = wiserItemsService.GetTablePrefixForEntity(entitySettingsOfParent);
+                                var mappedParentItemId = GetMappedId($"{parentEntityTablePrefix}{WiserTableNames.WiserItem}", idMapping, originalParentItemId, actionData, "id") ?? 0;
+                                actionData.LinkedObjectIdOriginal = originalParentItemId;
+                                actionData.LinkedObjectIdMapped = mappedParentItemId;
+                                actionData.LinkedObjectTableName = $"{parentEntityTablePrefix}{WiserTableNames.WiserItem}";
+
+                                actionData.NewValue = mappedParentItemId.ToString();
+
+                                actionData.MessageBuilder.AppendLine($"--> Mapped the parent item ID from '{originalParentItemId}' to '{mappedParentItemId}' based on the entity type of the parent item.");
+                            }
+
                             sqlParameters["itemId"] = actionData.ItemIdMapped;
                             sqlParameters["newValue"] = actionData.NewValue;
 

--- a/WiserTaskScheduler/WiserTaskScheduler/WiserTaskScheduler.csproj
+++ b/WiserTaskScheduler/WiserTaskScheduler/WiserTaskScheduler.csproj
@@ -14,8 +14,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="GeeksCoreLibrary.Modules.GclConverters.EvoPdf" Version="5.3.2507.4" />
-        <PackageReference Include="GeeksCoreLibrary.Modules.ScriptInterpreters.JavaScript" Version="5.3.2507.4" />
+        <PackageReference Include="GeeksCoreLibrary.Modules.GclConverters.EvoPdf" Version="5.3.2507.6" />
+        <PackageReference Include="GeeksCoreLibrary.Modules.ScriptInterpreters.JavaScript" Version="5.3.2507.6" />
         <PackageReference Include="jose-jwt" Version="5.1.1" />
         <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.4" />
         <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="9.0.4" />


### PR DESCRIPTION
# Describe your changes

When performing a merge the `parent_item_id` in the `wiser_item` tables was copied directly. This change retrieves the mapped value to ensure that the `parent_item_id` is the correct item in the production database.

## Type of change

Please check only ONE option.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested?

Tested by having items under a parent and checking during the merge if the correct IDs were found and afterwards in Wiser if they were visible under the correct item in the interface.

# Checklist before requesting a review
- [x] I have reviewed and tested my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I selected `develop` as the base branch and not `main`, or the pull request is a hotfix that needs to be done directly on `main`
- [x] I double checked all my changes and they contain no temporary test code, no code that is commented out and no changes that are not part of this branch
- [ ] I added new unit tests for my changes if applicable

# Related pull requests

N/A

# Link to Asana ticket

https://app.asana.com/1/5038780173035/project/29553867016121/task/1210856126133150
