### PR TITLE
Refactor mapping of styled output to fix incorrect mapping

### DIFF
--- a/WiserTaskScheduler/WiserTaskScheduler/Modules/Branches/Helpers/PrecompiledRegexes.cs
+++ b/WiserTaskScheduler/WiserTaskScheduler/Modules/Branches/Helpers/PrecompiledRegexes.cs
@@ -1,0 +1,21 @@
+using System.Text.RegularExpressions;
+
+namespace WiserTaskScheduler.Modules.Branches.Helpers;
+
+public static partial class PrecompiledRegexes
+{
+    /// <summary>
+    /// Matches a styled output identifier in the format "number-text".
+    /// E.g. "123-ExampleOutput".
+    /// </summary>
+    [GeneratedRegex(@"^(\d+)-(.+)$")]
+    public static partial Regex StyledOutputIdentifierRegex { get; }
+
+    /// <summary>
+    /// Matches a styled output body in the format "{StyledOutput~number}" or "{StyledOutput~number~parameter~value}".
+    /// E.g. "{StyledOutput~123}" or "{StyledOutput~123~param~value}".
+    /// The digit after "{StyledOutput~" is captured as a group as the whole digit. Preventing issues with mapping "{StyledOutput~10" as "{StyledOutput~1".
+    /// </summary>
+    [GeneratedRegex(@"\{StyledOutput~(\d+)")]
+    public static partial Regex StyledOutputBodyRegex { get; }
+}


### PR DESCRIPTION
# Describe your changes

The current mapping of references within the styled output was only performed on newly created styled outputs if they themselves got a different ID in production. The refactored way will apply mapping on all styled output formats if they have been modified during the current merge. At that moment the references use the branch IDs and we can map them to the production ones.

## Type of change

Please check only ONE option.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested?

Tested by having multiple references in changes to check if they are correctly mapped. This includes with and without parameters and cases as 1 and 10 to check if 10 isn't replaced with the ID for 1 and keeps an additional 0.

# Checklist before requesting a review
- [x] I have reviewed and tested my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I selected `develop` as the base branch and not `main`, or the pull request is a hotfix that needs to be done directly on `main`
- [x] I double checked all my changes and they contain no temporary test code, no code that is commented out and no changes that are not part of this branch
- [ ] I added new unit tests for my changes if applicable

# Related pull requests

N/A

# Link to Asana ticket

https://app.asana.com/1/5038780173035/project/7257459017111/task/1210195193691405
