### PR TITLE
Fixed order of actions in branch creation

### DIFF
--- a/WiserTaskScheduler/WiserTaskScheduler/Modules/Branches/Services/BranchQueueService.cs
+++ b/WiserTaskScheduler/WiserTaskScheduler/Modules/Branches/Services/BranchQueueService.cs
@@ -345,6 +345,10 @@ public class BranchQueueService(ILogService logService, ILogger<BranchQueueServi
                 await branchDatabaseConnection.ExecuteAsync(createTableResult.Rows[0].Field<string>("Create table"));
             }
 
+            // Create the wiser_id_mappings table in the new branch.
+            // This is used to know which IDs are already synced to the production environment.
+            await branchDatabaseHelpersService.CheckAndUpdateTablesAsync([WiserTableNames.WiserIdMappings]);
+
             // Cache some settings that we'll need later.
             var allLinkTypes = await wiserItemsService.GetAllLinkTypeSettingsAsync();
 
@@ -950,10 +954,6 @@ public class BranchQueueService(ILogService logService, ILogger<BranchQueueServi
                     errors.Add($"Unable to create stored procedure '{dataRow.Field<string>("ROUTINE_NAME")}' in the new branch, because of the following error: {exception}");
                 }
             }
-
-            // Create the wiser_id_mappings table in the new branch.
-            // This is used to know which IDs are already synced to the production environment.
-            await branchDatabaseHelpersService.CheckAndUpdateTablesAsync([WiserTableNames.WiserIdMappings]);
         }
         catch (Exception exception)
         {


### PR DESCRIPTION
# Describe your changes

When a branch is being created it would attempt to add data to a table that wasn't available yet. The order of actions has been changed back to before PR #322 so the creation of the table happens first instead of last.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested?

Please describe how you tested your changes and how you confirmed this functionality is not a breaking change.

# Checklist before requesting a review
- [x] I have reviewed and tested my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I selected `develop` as the base branch and not `main`, or the pull request is a hotfix that needs to be done directly on `main`
- [x] I double checked all my changes and they contain no temporary test code, no code that is commented out and no changes that are not part of this branch
- [x] I added new unit tests for my changes if applicable

# Related pull requests

None.

# Link to Asana ticket

Nah man.