### PR TITLE
Added feature to support variables from ResultSets in the <OAuth> value

### DIFF
--- a/WiserTaskScheduler/WiserTaskScheduler/Core/Interfaces/IOAuthService.cs
+++ b/WiserTaskScheduler/WiserTaskScheduler/Core/Interfaces/IOAuthService.cs
@@ -33,5 +33,5 @@ public interface IOAuthService
     /// <param name="apiName">The name of the API that gave an invalid access token.</param>
     /// <param name="resetRefreshToken">Optional: also resets the refresh token if true.</param>
     /// <returns></returns>
-    Task RequestWasUnauthorizedAsync(string apiName, bool resetRefreshToken);
+    Task RequestWasUnauthorizedAsync(string apiName, bool resetRefreshToken = false);
 }

--- a/WiserTaskScheduler/WiserTaskScheduler/Modules/HttpApis/Services/HttpApisService.cs
+++ b/WiserTaskScheduler/WiserTaskScheduler/Modules/HttpApis/Services/HttpApisService.cs
@@ -155,7 +155,15 @@ public class HttpApisService(IOAuthService oAuthService, IBodyService bodyServic
 
         if (!String.IsNullOrWhiteSpace(httpApi.OAuth))
         {
-            var (oauthState, authorizationHeaderValue, _, _) = await oAuthService.GetAccessTokenAsync(httpApi.OAuth);
+            var keyParts = useResultSet.Split('.');
+            var usingResultSet = ResultSetHelper.GetCorrectObject<JObject>(httpApi.SingleRequest ? keyParts[0] : useResultSet, ReplacementHelper.EmptyRows, resultSets);
+            var remainingKey = keyParts.Length > 1 ? useResultSet[(keyParts[0].Length + 1)..] : "";
+            var tuple = ReplacementHelper.PrepareText(httpApi.OAuth, usingResultSet, remainingKey, httpApi.HashSettings, htmlEncode: true);
+            var authStr = tuple.Item1;
+            var parameterKeys = tuple.Item2;
+            authStr = ReplacementHelper.ReplaceText(authStr, rows, parameterKeys, usingResultSet, httpApi.HashSettings, true);
+
+            var (oauthState, authorizationHeaderValue, _, _) = await oAuthService.GetAccessTokenAsync(authStr);
             switch (oauthState)
             {
                 case OAuthState.SuccessfullyRequestedNewToken:
@@ -165,7 +173,7 @@ public class HttpApisService(IOAuthService oAuthService, IBodyService bodyServic
                 case OAuthState.AuthenticationFailed:
                 case OAuthState.RefreshTokenFailed:
                 case OAuthState.NotEnoughInformation:
-                    await logService.LogWarning(logger, LogScopes.RunBody, httpApi.LogSettings, $"OAuth '{httpApi.OAuth}' authentication failed ({oauthState.ToString()}) for configuration '{configurationServiceName}' with time ID '{httpApi.TimeId}' and order '{httpApi.Order}'.", configurationServiceName, httpApi.TimeId, httpApi.Order, extraValuesToObfuscate);
+                    await logService.LogWarning(logger, LogScopes.RunBody, httpApi.LogSettings, $"OAuth '{authStr}' authentication failed ({oauthState.ToString()}) for configuration '{configurationServiceName}' with time ID '{httpApi.TimeId}' and order '{httpApi.Order}'.", configurationServiceName, httpApi.TimeId, httpApi.Order, extraValuesToObfuscate);
                     break;
                 case OAuthState.WaitingForManualAuthentication:
                     // If we're waiting for manual authentication, return an unauthorized response and don't attempt to execute the API request.

--- a/WiserTaskScheduler/WiserTaskScheduler/Modules/HttpApis/Services/HttpApisService.cs
+++ b/WiserTaskScheduler/WiserTaskScheduler/Modules/HttpApis/Services/HttpApisService.cs
@@ -159,11 +159,10 @@ public class HttpApisService(IOAuthService oAuthService, IBodyService bodyServic
             var usingResultSet = ResultSetHelper.GetCorrectObject<JObject>(httpApi.SingleRequest ? keyParts[0] : useResultSet, ReplacementHelper.EmptyRows, resultSets);
             var remainingKey = keyParts.Length > 1 ? useResultSet[(keyParts[0].Length + 1)..] : "";
             var tuple = ReplacementHelper.PrepareText(httpApi.OAuth, usingResultSet, remainingKey, httpApi.HashSettings, htmlEncode: true);
-            var authStr = tuple.Item1;
             var parameterKeys = tuple.Item2;
-            authStr = ReplacementHelper.ReplaceText(authStr, rows, parameterKeys, usingResultSet, httpApi.HashSettings, true);
+            var resolvedAuthName = ReplacementHelper.ReplaceText(tuple.Item1, rows, parameterKeys, usingResultSet, httpApi.HashSettings, true);
 
-            var (oauthState, authorizationHeaderValue, _, _) = await oAuthService.GetAccessTokenAsync(authStr, true, configurationServiceName, httpApi.TimeId, httpApi.Order);
+            var (oauthState, authorizationHeaderValue, _, _) = await oAuthService.GetAccessTokenAsync(resolvedAuthName, true, configurationServiceName, httpApi.TimeId, httpApi.Order);
             switch (oauthState)
             {
                 case OAuthState.SuccessfullyRequestedNewToken:
@@ -173,7 +172,7 @@ public class HttpApisService(IOAuthService oAuthService, IBodyService bodyServic
                 case OAuthState.AuthenticationFailed:
                 case OAuthState.RefreshTokenFailed:
                 case OAuthState.NotEnoughInformation:
-                    await logService.LogWarning(logger, LogScopes.RunBody, httpApi.LogSettings, $"OAuth '{authStr}' authentication failed ({oauthState.ToString()}) for configuration '{configurationServiceName}' with time ID '{httpApi.TimeId}' and order '{httpApi.Order}'.", configurationServiceName, httpApi.TimeId, httpApi.Order, extraValuesToObfuscate);
+                    await logService.LogWarning(logger, LogScopes.RunBody, httpApi.LogSettings, $"OAuth '{resolvedAuthName}' authentication failed ({oauthState.ToString()}) for configuration '{configurationServiceName}' with time ID '{httpApi.TimeId}' and order '{httpApi.Order}'.", configurationServiceName, httpApi.TimeId, httpApi.Order, extraValuesToObfuscate);
                     break;
                 case OAuthState.WaitingForManualAuthentication:
                     // If we're waiting for manual authentication, return an unauthorized response and don't attempt to execute the API request.


### PR DESCRIPTION
# Describe your changes

Added the result set variable resolving code to the oauth code as well, so you can use variables in the <OAuth> tag.

## Type of change

Please check only ONE option.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested?

Locally, with a local configuration. Tested with and without a variable.

# Checklist before requesting a review
- [X] I have reviewed and tested my changes
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] I selected `develop` as the base branch and not `main`, or the pull request is a hotfix that needs to be done directly on `main`
- [X] I double checked all my changes and they contain no temporary test code, no code that is commented out and no changes that are not part of this branch
- [ ] I added new unit tests for my changes if applicable

# Related pull requests



# Link to Asana ticket

https://app.asana.com/1/5038780173035/project/760894706380588/task/1211408899731972
