### PR TITLE
If using refresh token fails, reset the refresh token

### DIFF
--- a/WiserTaskScheduler/WiserTaskScheduler/Core/Interfaces/IOAuthService.cs
+++ b/WiserTaskScheduler/WiserTaskScheduler/Core/Interfaces/IOAuthService.cs
@@ -20,14 +20,18 @@ public interface IOAuthService
     /// </summary>
     /// <param name="apiName">The name of the API to get the access token from.</param>
     /// <param name="retryAfterWrongRefreshToken">Retry to get an access token using login credentials if the refresh token didn't give a new access token.</param>
+    /// <param name="configurationName">The configuration that is currently running, for logging purposes</param>
+    /// <param name="timeId">The timeId that is currently running, for logging purposes</param>
+    /// <param name="order">The order that is currently running, for logging purposes</param>
     /// <returns>Returns the access token to the API.</returns>
-    Task<(OAuthState State, string AuthorizationHeaderValue, JToken ResponseBody, HttpStatusCode ResponseStatusCode)> GetAccessTokenAsync(string apiName, bool retryAfterWrongRefreshToken = true);
+    Task<(OAuthState State, string AuthorizationHeaderValue, JToken ResponseBody, HttpStatusCode ResponseStatusCode)> GetAccessTokenAsync(string apiName, bool retryAfterWrongRefreshToken, string configurationName, int timeId, int order);
 
     /// <summary>
     /// Tells that the specified API gave an access token was invalid and caused the request to be "Unauthorized".
     /// API information will be cleared so the next request will request a new access token.
     /// </summary>
     /// <param name="apiName">The name of the API that gave an invalid access token.</param>
+    /// <param name="resetRefreshToken">Optional: also resets the refresh token if true.</param>
     /// <returns></returns>
-    Task RequestWasUnauthorizedAsync(string apiName);
+    Task RequestWasUnauthorizedAsync(string apiName, bool resetRefreshToken);
 }

--- a/WiserTaskScheduler/WiserTaskScheduler/Core/Services/OAuthService.cs
+++ b/WiserTaskScheduler/WiserTaskScheduler/Core/Services/OAuthService.cs
@@ -76,7 +76,7 @@ public class OAuthService(IOptions<GclSettings> gclSettings, ILogService logServ
     }
 
     /// <inheritdoc />
-    public async Task<(OAuthState State, string AuthorizationHeaderValue, JToken ResponseBody, HttpStatusCode ResponseStatusCode)> GetAccessTokenAsync(string apiName, bool retryAfterWrongRefreshToken = true)
+    public async Task<(OAuthState State, string AuthorizationHeaderValue, JToken ResponseBody, HttpStatusCode ResponseStatusCode)> GetAccessTokenAsync(string apiName, bool retryAfterWrongRefreshToken, string configurationName, int timeId, int order)
     {
         (OAuthState State, string AuthorizationHeaderValue, JToken ResponseBody, HttpStatusCode ResponseStatusCode) result = (OAuthState.NotEnoughInformation, null, null, HttpStatusCode.Unauthorized);
         using var scope = serviceProvider.CreateScope();
@@ -117,7 +117,7 @@ public class OAuthService(IOptions<GclSettings> gclSettings, ILogService logServ
                     switch (oAuthApi.GrantType)
                     {
                         case OAuthGrantType.RefreshToken:
-                            await logService.LogInformation(logger, LogScopes.RunBody, oAuthApi.LogSettings, $"Requesting new access token for '{apiName}' using refresh token.", LogName);
+                            await logService.LogInformation(logger, LogScopes.RunBody, oAuthApi.LogSettings, $"Requesting new access token for '{apiName}' using refresh token.", configurationName, timeId, order);
 
                             result.State = OAuthState.RefreshTokenFailed;
                             formData.Add(new KeyValuePair<string, string>("grant_type", "refresh_token"));
@@ -141,7 +141,7 @@ public class OAuthService(IOptions<GclSettings> gclSettings, ILogService logServ
                             throw new NotImplementedException("OAuthGrantType.Implicit is not supported yet");
 
                         case OAuthGrantType.PasswordCredentials:
-                            await logService.LogInformation(logger, LogScopes.RunBody, oAuthApi.LogSettings, $"Requesting new access token for '{apiName}' using username and password.", LogName);
+                            await logService.LogInformation(logger, LogScopes.RunBody, oAuthApi.LogSettings, $"Requesting new access token for '{apiName}' using username and password.", configurationName, timeId, order);
 
                             formData.Add(new KeyValuePair<string, string>("grant_type", "password"));
                             formData.Add(new KeyValuePair<string, string>("username", oAuthApi.Username));
@@ -150,7 +150,7 @@ public class OAuthService(IOptions<GclSettings> gclSettings, ILogService logServ
                             break;
 
                         case OAuthGrantType.ClientCredentials:
-                            await logService.LogInformation(logger, LogScopes.RunBody, oAuthApi.LogSettings, $"Requesting new access token for '{apiName}' using client credentials.", LogName);
+                            await logService.LogInformation(logger, LogScopes.RunBody, oAuthApi.LogSettings, $"Requesting new access token for '{apiName}' using client credentials.", configurationName, timeId, order);
 
                             formData.Add(new KeyValuePair<string, string>("grant_type", "client_credentials"));
 
@@ -202,7 +202,7 @@ public class OAuthService(IOptions<GclSettings> gclSettings, ILogService logServ
                             catch (Exception exception)
                             {
                                 // If the conversion fails, then log it and use the string value instead.
-                                await logService.LogWarning(logger, LogScopes.RunBody, oAuthApi.LogSettings, $"Failed to convert claim value to specified type. Using string instead. Exception: {exception}", LogName);
+                                await logService.LogWarning(logger, LogScopes.RunBody, oAuthApi.LogSettings, $"Failed to convert claim value to specified type. Using string instead. Exception: {exception}", configurationName, timeId, order);
                                 claims[claim.Name] = claim.Value;
                             }
                         }
@@ -258,7 +258,7 @@ public class OAuthService(IOptions<GclSettings> gclSettings, ILogService logServ
 
                 if (!response.IsSuccessStatusCode)
                 {
-                    await logService.LogError(logger, LogScopes.RunBody, oAuthApi.LogSettings, $"Failed to get access token for {oAuthApi.ApiName}. Received: {response.StatusCode}\n{json}", LogName);
+                    await logService.LogError(logger, LogScopes.RunBody, oAuthApi.LogSettings, $"Failed to get access token for {oAuthApi.ApiName}. Received: {response.StatusCode}\n{json}", configurationName, timeId, order);
                 }
                 else
                 {
@@ -278,7 +278,7 @@ public class OAuthService(IOptions<GclSettings> gclSettings, ILogService logServ
 
                     oAuthApi.ExpireTime -= oAuthApi.ExpireTimeOffset;
 
-                    await logService.LogInformation(logger, LogScopes.RunBody, oAuthApi.LogSettings, $"A new access token has been retrieved for {oAuthApi.ApiName} and is valid till {oAuthApi.ExpireTime.ToLocalTime()}", LogName);
+                    await logService.LogInformation(logger, LogScopes.RunBody, oAuthApi.LogSettings, $"A new access token has been retrieved for {oAuthApi.ApiName} and is valid till {oAuthApi.ExpireTime.ToLocalTime()}", configurationName, timeId, order);
 
                     result.State = OAuthState.SuccessfullyRequestedNewToken;
                 }
@@ -301,8 +301,8 @@ public class OAuthService(IOptions<GclSettings> gclSettings, ILogService logServ
                 break;
             case OAuthState.RefreshTokenFailed:
                 // Retry to get the token with the login credentials if the refresh token was invalid.
-                await RequestWasUnauthorizedAsync(apiName);
-                result = await GetAccessTokenAsync(apiName, false);
+                await RequestWasUnauthorizedAsync(apiName, true);
+                result = await GetAccessTokenAsync(apiName, false, configurationName, timeId, order);
                 break;
             case OAuthState.UsingAlreadyExistingToken:
                 result.AuthorizationHeaderValue = $"{oAuthApi.TokenType} {oAuthApi.AccessToken}";
@@ -322,7 +322,7 @@ public class OAuthService(IOptions<GclSettings> gclSettings, ILogService logServ
     }
 
     /// <inheritdoc />
-    public async Task RequestWasUnauthorizedAsync(string apiName)
+    public async Task RequestWasUnauthorizedAsync(string apiName, bool resetRefreshToken = false)
     {
         var oAuthApi = configuration.OAuths.SingleOrDefault(oAuth => oAuth.ApiName.Equals(apiName));
 
@@ -334,6 +334,11 @@ public class OAuthService(IOptions<GclSettings> gclSettings, ILogService logServ
         oAuthApi.AccessToken = null;
         oAuthApi.TokenType = null;
         oAuthApi.ExpireTime = DateTime.MinValue;
+
+        if (resetRefreshToken)
+        {
+            oAuthApi.RefreshToken = null;
+        }
 
         await SaveToDatabaseAsync(oAuthApi);
     }

--- a/WiserTaskScheduler/WiserTaskScheduler/Modules/HttpApis/Services/HttpApisService.cs
+++ b/WiserTaskScheduler/WiserTaskScheduler/Modules/HttpApis/Services/HttpApisService.cs
@@ -155,7 +155,7 @@ public class HttpApisService(IOAuthService oAuthService, IBodyService bodyServic
 
         if (!String.IsNullOrWhiteSpace(httpApi.OAuth))
         {
-            var (oauthState, authorizationHeaderValue, _, _) = await oAuthService.GetAccessTokenAsync(httpApi.OAuth);
+            var (oauthState, authorizationHeaderValue, _, _) = await oAuthService.GetAccessTokenAsync(httpApi.OAuth, true, configurationServiceName, httpApi.TimeId, httpApi.Order);
             switch (oauthState)
             {
                 case OAuthState.SuccessfullyRequestedNewToken:


### PR DESCRIPTION
# Describe your changes

If using a refresh token fails, the refresh token is now reset
Also updated OAuthService logging to use correct configuration info

## Type of change

Please check only ONE option.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested?

Entered an invalid refresh token in the database and ran a local configuration. The authentication kept failing because the token was never reset. This fix actually removed the invalid refresh token so a fresh one was requested.

# Checklist before requesting a review
- [X] I have reviewed and tested my changes
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I selected `develop` as the base branch and not `main`, or the pull request is a hotfix that needs to be done directly on `main`
- [X] I double checked all my changes and they contain no temporary test code, no code that is commented out and no changes that are not part of this branch
- [ ] I added new unit tests for my changes if applicable

# Related pull requests

This one should be merged with this one for Fetim
https://github.com/happy-geeks/wiser-task-scheduler/pull/335

# Link to Asana ticket

https://app.asana.com/1/5038780173035/project/760894706380588/task/1211408899731972
